### PR TITLE
Change authorization to make use of a JWT in header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /config/database.json
 /cookie
 /ecosystem.config.js
+/private.key
+/public.key

--- a/app.js
+++ b/app.js
@@ -5,7 +5,6 @@ const createError = require('http-errors')
 const express = require('express')
 const logger = require('morgan')
 const { sendError } = require('./app/middlewares/error')
-//const { authenticate } = require('./app/middlewares/auth')
 
 const groupsRouter = require('./app/routes/groups')
 const usersRouter = require('./app/routes/users')
@@ -19,7 +18,6 @@ require('express-async-errors')
 app.use(logger('dev'))
 app.use(express.json())
 app.use(express.urlencoded({extended: false}))
-//app.use(authenticate)
 
 app.use('/api/v1/groups', groupsRouter)
 app.use('/api/v1/users', usersRouter)
@@ -31,7 +29,7 @@ app.use(() => {
     throw createError(404)
 })
 
-app.use((err, req, res) => {
+app.use((err, req, res, next) => {
     sendError(res, err.status || 500, err.message)
 })
 

--- a/app/controllers/v1/ban.js
+++ b/app/controllers/v1/ban.js
@@ -1,16 +1,17 @@
 'use strict'
-const { param, body, oneOf } = require('express-validator')
+const { param, body, header, oneOf } = require('express-validator')
 
 const banService = require('../../services/ban')
 
 exports.validate = method => {
     switch (method) {
         case 'getBans':
-            return []
+            return [
+                header('authorization').exists().isString()
+            ]
         case 'ban':
             return [
-                body('id').exists().isNumeric(),
-                body('key').exists().isString(),
+                header('authorization').exists().isString(),
                 body('userId').exists().isNumeric(),
                 body('by').exists().isNumeric(),
                 body('reason').exists().isString(),
@@ -18,9 +19,8 @@ exports.validate = method => {
             ]
         case 'putBan':
             return oneOf([
+                header('authorization').exists().isString(),
                 param('userId').exists().isNumeric(),
-                body('id').exists().isNumeric(),
-                body('key').exists().isString(),
                 body('by').exists().isNumeric(),
                 body('unbanned').exists().isBoolean()
             ])

--- a/app/controllers/v1/group.js
+++ b/app/controllers/v1/group.js
@@ -1,5 +1,5 @@
 'use strict'
-const { param, body, oneOf } = require('express-validator')
+const { param, body, header, oneOf } = require('express-validator')
 
 const groupService = require('../../services/group')
 
@@ -7,9 +7,8 @@ exports.validate = method => {
     switch (method) {
         case 'suspend':
             return [
+                header('authorization').exists().isString(),
                 param('groupId').isNumeric(),
-                body('id').exists().isNumeric(),
-                body('key').exists().isString(),
                 body('userId').exists().isNumeric(),
                 body('by').exists().isNumeric(),
                 body('reason').exists().isString(),
@@ -18,39 +17,42 @@ exports.validate = method => {
             ]
         case 'getRank':
             return [
+                header('authorization').exists().isString(),
                 param('groupId').isNumeric(),
                 param('userId').isNumeric()
             ]
         case 'promote':
             return [
+                header('authorization').exists().isString(),
                 param('groupId').isNumeric(),
                 param('userId').isNumeric(),
-                body('id').exists().isNumeric(),
-                body('key').exists().isString(),
                 body('by').optional().isNumeric()
             ]
         case 'getShout':
             return [
+                header('authorization').exists().isString(),
                 param('groupId').isNumeric()
             ]
         case 'getRole':
             return [
+                header('authorization').exists().isString(),
                 param('groupId').isNumeric(),
                 param('userId').isNumeric()
             ]
         case 'getSuspensions':
             return [
+                header('authorization').exists().isString(),
                 param('groupId').isNumeric()
             ]
         case 'getTrainings':
             return [
+                header('authorization').exists().isString(),
                 param('groupId').isNumeric()
             ]
         case 'hostTraining':
             return [
+                header('authorization').exists().isString(),
                 param('groupId').isNumeric(),
-                body('id').exists().isNumeric(),
-                body('key').exists().isString(),
                 body('by').exists().isString(),
                 body('type').exists().isString(),
                 body('date').exists().isNumeric(),
@@ -58,74 +60,69 @@ exports.validate = method => {
             ]
         case 'getExiles':
             return [
+                header('authorization').exists().isString(),
                 param('groupId').isNumeric()
             ]
         case 'getSuspension':
             return [
+                header('authorization').exists().isString(),
                 param('groupId').isNumeric(),
                 param('userId').isNumeric()
             ]
         case 'getTraining':
             return [
+                header('authorization').exists().isString(),
                 param('groupId').isNumeric(),
                 param('trainingId').isNumeric()
             ]
         case 'shout':
             return [
+                header('authorization').exists().isString(),
                 param('groupId').isNumeric(),
-                body('id').exists().isNumeric(),
-                body('key').exists().isString(),
                 body('by').exists().isNumeric(),
                 body('message').exists().isString()
             ]
         case 'putTraining': // This is ugly because epxress-validator doesn't support nested oneOfs
             return oneOf([
                 [
+                    header('authorization').exists().isString(),
                     param('groupId').isNumeric(),
                     param('trainingId').isNumeric(),
-                    body('id').exists().isNumeric(),
-                    body('key').exists().isString(),
                     body('type').exists().isString()
                 ], [
+                    header('authorization').exists().isString(),
                     param('groupId').isNumeric(),
                     param('trainingId').isNumeric(),
-                    body('id').exists().isNumeric(),
-                    body('key').exists().isString(),
                     body('date').exists().isNumeric()
                 ], [
+                    header('authorization').exists().isString(),
                     param('groupId').isNumeric(),
                     param('trainingId').isNumeric(),
-                    body('id').exists().isNumeric(),
-                    body('key').exists().isString(),
                     body('specialnotes').exists().isString()
                 ], [
+                    header('authorization').exists().isString(),
                     param('groupId').isNumeric(),
                     param('trainingId').isNumeric(),
-                    body('id').exists().isNumeric(),
-                    body('key').exists().isString(),
                     body('by').exists().isString()
                 ], [
+                    header('authorization').exists().isString(),
                     param('groupId').isNumeric(),
                     param('trainingId').isNumeric(),
-                    body('id').exists().isNumeric(),
-                    body('key').exists().isString(),
                     body('cancelled').exists().isBoolean(),
                     body('reason').exists().isBoolean(),
                     body('by').exists().isString()
                 ], [
+                    header('authorization').exists().isString(),
                     param('groupId').isNumeric(),
                     param('trainingId').isNumeric(),
-                    body('id').exists().isNumeric(),
-                    body('key').exists().isString(),
                     body('finished').exists().isBoolean(),
                     body('by').exists().isString()
                 ]
             ])
             /*return [
+                header('authorization').exists().isString(),
                 param('groupId').isNumeric(),
                 param('trainingId').isNumeric(),
-                body('id').exists().isNumeric(),
-                body('key').exists().isString(),
                 oneOf([
                     body('type').exists().isString(),
                     body('date').exists().isNumeric(),
@@ -145,36 +142,31 @@ exports.validate = method => {
         case 'putSuspension':
             return oneOf([
                 [
+                    header('authorization').exists().isString(),
                     param('groupId').isNumeric(),
                     param('userId').isNumeric(),
-                    body('id').exists().isNumeric(),
-                    body('key').exists().isString(),
                     body('by').exists().isNumeric()
                 ], [
+                    header('authorization').exists().isString(),
                     param('groupId').isNumeric(),
                     param('userId').isNumeric(),
-                    body('id').exists().isNumeric(),
-                    body('key').exists().isString(),
                     body('reason').exists().isString()
                 ], [
+                    header('authorization').exists().isString(),
                     param('groupId').isNumeric(),
                     param('userId').isNumeric(),
-                    body('id').exists().isNumeric(),
-                    body('key').exists().isString(),
                     body('rankback').exists().isNumeric()
                 ], [
+                    header('authorization').exists().isString(),
                     param('groupId').isNumeric(),
                     param('userId').isNumeric(),
-                    body('id').exists().isNumeric(),
-                    body('key').exists().isString(),
                     body('cancelled').exists().isBoolean(),
                     body('reason').exists().isBoolean(),
                     body('by').exists().isNumeric()
                 ], [
+                    header('authorization').exists().isString(),
                     param('groupId').isNumeric(),
                     param('userId').isNumeric(),
-                    body('id').exists().isNumeric(),
-                    body('key').exists().isString(),
                     body('extended').exists().isBoolean(),
                     body('duration').exists().isNumeric(),
                     body('reason').exists().isString(),
@@ -182,10 +174,9 @@ exports.validate = method => {
                 ]
             ])
             /*return [
+                header('authorization').exists().isString(),
                 param('groupId').isNumeric(),
                 param('userId').isNumeric(),
-                body('id').exists().isNumeric(),
-                body('key').exists().isString(),
                 oneOf([
                     body('by').exists().isNumeric(),
                     body('reason').exists().isString(),
@@ -205,6 +196,7 @@ exports.validate = method => {
             ]*/
         case 'getGroup':
             return [
+                header('authorization').exists().isString(),
                 param('groupId').isNumeric()
             ]
     }

--- a/app/controllers/v1/qotd.js
+++ b/app/controllers/v1/qotd.js
@@ -1,5 +1,5 @@
 'use strict'
-const { body } = require('express-validator')
+const { body, header } = require('express-validator')
 
 const qotdService = require('../../services/qotd')
 
@@ -7,8 +7,7 @@ exports.validate = method => {
     switch (method) {
         case 'suggest':
             return [
-                body('id').exists().isNumeric(),
-                body('key').exists().isString(),
+                header('authorization').exists().isString(),
                 body('qotd').exists().isString(),
                 body('by').exists().isString()
             ]

--- a/app/controllers/v1/status.js
+++ b/app/controllers/v1/status.js
@@ -1,10 +1,14 @@
 'use strict'
+const { header } = require('express-validator')
+
 const statusService = require('../../services/status')
 
 exports.validate = method => {
     switch (method) {
         case 'getStatus':
-            return []
+            return [
+                header('authorization').exists().isString()
+            ]
     }
 }
 

--- a/app/controllers/v1/user.js
+++ b/app/controllers/v1/user.js
@@ -1,5 +1,5 @@
 'use strict'
-const { param } = require('express-validator')
+const { param, header } = require('express-validator')
 
 const userService = require('../../services/user')
 
@@ -7,10 +7,12 @@ exports.validate = method => {
     switch (method) {
         case 'getUserId':
             return [
+                header('authorization').exists().isString(),
                 param('username').isString()
             ]
         case 'getJoinDate':
             return [
+                header('authorization').exists().isString(),
                 param('userId').isNumeric()
             ]
     }

--- a/app/middlewares/auth.js
+++ b/app/middlewares/auth.js
@@ -1,7 +1,10 @@
 'use strict'
+const createError = require('http-errors')
+
 const authService = require('../services/auth')
 
-exports.authenticate = async (req, res, next) => {
-    await authService.authenticate(req.body.id, req.body.key)
+exports.authenticate = (req, res, next) => {
+    const token = req.header('authorization').replace('Bearer ', '')
+    if (!authService.authenticate(token)) throw createError(401, 'Incorrect authentication key')
     next()
 }

--- a/app/routes/bans.js
+++ b/app/routes/bans.js
@@ -8,7 +8,7 @@ const { handleValidationResult } = require('../middlewares/error')
 const { parseParams } = require('../middlewares/request')
 const { authenticate } = require('../middlewares/auth')
 
-router.get('/', banController.validate('getBans'), handleValidationResult, banController.getBans)
+router.get('/', banController.validate('getBans'), handleValidationResult, authenticate, banController.getBans)
 
 router.post('/', banController.validate('ban'), handleValidationResult, authenticate, banController.ban)
 

--- a/app/routes/groups.js
+++ b/app/routes/groups.js
@@ -8,49 +8,49 @@ const { handleValidationResult } = require('../middlewares/error')
 const { parseParams } = require('../middlewares/request')
 const { authenticate } = require('../middlewares/auth')
 
-router.post('/:groupId/suspensions', groupController.validate('suspend'), handleValidationResult,
-    authenticate, parseParams, groupController.suspend)
+router.post('/:groupId/suspensions', groupController.validate('suspend'), handleValidationResult, authenticate,
+    parseParams, groupController.suspend)
 
-router.get('/:groupId/rank/:userId', groupController.validate('getRank'), handleValidationResult, parseParams,
-    groupController.getRank)
+router.get('/:groupId/rank/:userId', groupController.validate('getRank'), handleValidationResult, authenticate,
+    parseParams, groupController.getRank)
 
 router.post('/:groupId/promote/:userId', groupController.validate('promote'), handleValidationResult,
     authenticate, parseParams, groupController.promote)
 
-router.get('/:groupId/shout', groupController.validate('getShout'), handleValidationResult, parseParams,
-    groupController.getShout)
+router.get('/:groupId/shout', groupController.validate('getShout'), handleValidationResult, authenticate,
+    parseParams, groupController.getShout)
 
-router.get('/:groupId/role/:userId', groupController.validate('getRole'), handleValidationResult, parseParams,
-    groupController.getRole)
+router.get('/:groupId/role/:userId', groupController.validate('getRole'), handleValidationResult, authenticate,
+    parseParams, groupController.getRole)
 
 router.get('/:groupId/suspensions', groupController.validate('getSuspensions'), handleValidationResult,
-    parseParams, groupController.getSuspensions)
+    authenticate, parseParams, groupController.getSuspensions)
 
 router.get('/:groupId/trainings', groupController.validate('getTrainings'), handleValidationResult,
-    parseParams, groupController.getTrainings)
+    authenticate, parseParams, groupController.getTrainings)
 
 router.post('/:groupId/trainings', groupController.validate('hostTraining'), handleValidationResult,
     authenticate, parseParams, groupController.hostTraining)
 
-router.get('/:groupId/exiles', groupController.validate('getExiles'), handleValidationResult, parseParams,
-    groupController.getExiles)
+router.get('/:groupId/exiles', groupController.validate('getExiles'), handleValidationResult, authenticate,
+    parseParams, groupController.getExiles)
 
 router.get('/:groupId/suspensions/:userId', groupController.validate('getSuspension'), handleValidationResult,
-    parseParams, groupController.getSuspension)
+    authenticate, parseParams, groupController.getSuspension)
 
 router.get('/:groupId/trainings/:trainingId', groupController.validate('getTraining'), handleValidationResult,
-    parseParams, groupController.getTraining)
+    authenticate, parseParams, groupController.getTraining)
 
-router.post('/:groupId/shout', groupController.validate('shout'), handleValidationResult, parseParams,
-    groupController.shout)
+router.post('/:groupId/shout', groupController.validate('shout'), handleValidationResult, authenticate,
+    parseParams, groupController.shout)
 
 router.put('/:groupId/trainings/:trainingId', groupController.validate('putTraining'), handleValidationResult,
-    parseParams, groupController.putTraining)
+    authenticate, parseParams, groupController.putTraining)
 
 router.put('/:groupId/suspensions/:userId', groupController.validate('putSuspension'), handleValidationResult,
-    parseParams, groupController.putSuspension)
+    authenticate, parseParams, groupController.putSuspension)
 
-router.get('/:groupId', groupController.validate('getGroup'), handleValidationResult, parseParams,
-    groupController.getGroup)
+router.get('/:groupId', groupController.validate('getGroup'), handleValidationResult, authenticate,
+    parseParams, groupController.getGroup)
 
 module.exports = router

--- a/app/routes/status.js
+++ b/app/routes/status.js
@@ -5,7 +5,9 @@ const router = express.Router()
 const statusController = require('../controllers/v1/status')
 
 const { handleValidationResult } = require('../middlewares/error')
+const { authenticate } = require('../middlewares/auth')
 
-router.get('/', statusController.validate('getStatus'), handleValidationResult, statusController.getStatus)
+router.get('/', statusController.validate('getStatus'), handleValidationResult, authenticate, statusController
+    .getStatus)
 
 module.exports = router

--- a/app/routes/users.js
+++ b/app/routes/users.js
@@ -6,11 +6,12 @@ const userController = require('../controllers/v1/user')
 
 const { handleValidationResult } = require('../middlewares/error')
 const { parseParams } = require('../middlewares/request')
+const { authenticate } = require('../middlewares/auth')
 
-router.get('/:username/user-id', userController.validate('getUserId'), handleValidationResult, userController
-    .getUserId)
+router.get('/:username/user-id', userController.validate('getUserId'), handleValidationResult, authenticate,
+    userController.getUserId)
 
-router.get('/:userId/join-date', userController.validate('getJoinDate'), handleValidationResult, parseParams,
-    userController.getJoinDate)
+router.get('/:userId/join-date', userController.validate('getJoinDate'), handleValidationResult, authenticate,
+    parseParams, userController.getJoinDate)
 
 module.exports = router

--- a/app/services/auth.js
+++ b/app/services/auth.js
@@ -1,13 +1,23 @@
 'use strict'
-const createError = require('http-errors')
+const jwt = require('jsonwebtoken')
+const fs = require('fs')
 
-const models = require('../models')
+const privateKey = fs.readFileSync('private.key', 'utf8')
+const publicKey = fs.readFileSync('public.key', 'utf8')
 
-exports.authenticate = async (id, key) => {
-    const admin = await models.Admin.findById(id)
-    if (admin !== null && key === admin.key) {
+exports.authenticate = token => {
+    try {
+        exports.verify(token)
         return true
-    } else {
-        throw createError(401, 'Incorrect authentication key')
+    } catch {
+        return false
     }
+}
+
+exports.sign = payload => {
+    return jwt.sign(payload, privateKey, { algorithm: 'RS256' })
+}
+
+exports.verify = token => {
+    return jwt.verify(token, publicKey, { algorithm: ['RS256'] })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -426,6 +426,11 @@
         "fill-range": "^7.0.1"
       }
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-writer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
@@ -887,6 +892,14 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "editorconfig": {
@@ -2007,6 +2020,30 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -2016,6 +2053,25 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "latest-version": {
@@ -2051,6 +2107,41 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "long": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "express-async-errors": "^3.1.1",
     "express-validator": "^6.3.1",
     "http-errors": "^1.7.3",
+    "jsonwebtoken": "^8.5.1",
     "morgan": "^1.9.1",
     "noblox.js": "^4.2.6",
     "node-cron": "^2.0.3",


### PR DESCRIPTION
Currently, the API authorizes requests via the id and key fields in incoming requests' body. It's however impossible to send GET requests with a body from Roblox and it's mainly better practice to use a Authorization header for authorization, so this PR implements that. 

Resolves #9 