### PR TITLE
Loop through join requests pages by using cursors

### DIFF
--- a/app/jobs/accept-join-requests.js
+++ b/app/jobs/accept-join-requests.js
@@ -5,33 +5,38 @@ const DiscordMessageJob = require('./discord-message')
 
 const groupService = require('../services/group')
 
-class AcceptJoinRequestsJob {
+module.exports = class AcceptJoinRequestsJob {
     perform = async groupId => {
         try {
             const exiles = await groupService.getExiles()
             const suspensions = await groupService.getSuspensions()
-            const requests = await roblox.getJoinRequests(groupId)
-            for (const request of requests.data) {
-                const userId = request.requester.userId
-                if (exiles.find(exile => exile.userId === userId)) {
-                    await roblox.handleJoinRequest(groupId, userId, false)
-                    await (new DiscordMessageJob()).perform('log', `Declined **${request.requester
+            let cursor = null
+            do {
+                const requests = await roblox.getJoinRequests({
+                    group: groupId,
+                    cursor: cursor
+                })
+                for (const request of requests.data) {
+                    const userId = request.requester.userId
+                    if (exiles.find(exile => exile.userId === userId)) {
+                        await roblox.handleJoinRequest(groupId, userId, false)
+                        await (new DiscordMessageJob()).perform('log', `Declined **${request.requester
                             .username}**'s join request`)
-                } else {
-                    await roblox.handleJoinRequest(groupId, userId, true)
-                    await (new DiscordMessageJob()).perform('log', `Accepted **${request.requester
+                    } else {
+                        await roblox.handleJoinRequest(groupId, userId, true)
+                        await (new DiscordMessageJob()).perform('log', `Accepted **${request.requester
                             .username}**'s join request`)
-                    if (suspensions.find(suspension => suspension.userId === userId)) {
-                        await roblox.setRank(groupId, userId, 2)
-                        await (new DiscordMessageJob()).perform('log', `Promoted **${request.requester
-                            .username}** from **Customer** to **Suspended**`)
+                        if (suspensions.find(suspension => suspension.userId === userId)) {
+                            await roblox.setRank(groupId, userId, 2)
+                            await (new DiscordMessageJob()).perform('log', `Promoted **${request.requester
+                                .username}** from **Customer** to **Suspended**`)
+                        }
                     }
                 }
-            }
+                cursor = requests.nextPageCursor
+            } while (cursor)
         } catch (err) {
             console.error(err)
         }
     }
 }
-
-module.exports = AcceptJoinRequestsJob

--- a/app/jobs/accept-mt-join-requests.js
+++ b/app/jobs/accept-mt-join-requests.js
@@ -6,21 +6,28 @@ const DiscordMessageJob = require('./discord-message')
 class AcceptMtJoinRequestsJob {
     perform = async (groupId, mtGroupId) => {
         try {
-            const requests = await roblox.getJoinRequests(mtGroupId)
-            for (const request of requests.data) {
-                const userId = request.requester.userId
-                const rank = await roblox.getRankInGroup(groupId, userId)
-                if (rank >= 100) {
-                    await roblox.handleJoinRequest(mtGroupId, userId, true)
-                    await roblox.setRank(mtGroupId, userId, rank)
-                    await (new DiscordMessageJob()).perform('log', `Accepted **${request.requester
-                            .username}**'s MT join request`)
-                } else {
-                    await roblox.handleJoinRequest(mtGroupId, userId, false)
-                    await (new DiscordMessageJob()).perform('log', `Declined **${request.requester
-                            .username}**'s MT join request`)
+            let cursor = null
+            do {
+                const requests = await roblox.getJoinRequests({
+                    group: mtGroupId,
+                    cursor: cursor
+                })
+                for (const request of requests.data) {
+                    const userId = request.requester.userId
+                    const rank = await roblox.getRankInGroup(groupId, userId)
+                    if (rank >= 100) {
+                        await roblox.handleJoinRequest(mtGroupId, userId, true)
+                        await roblox.setRank(mtGroupId, userId, rank)
+                        await (new DiscordMessageJob()).perform('log', `Accepted **${request.requester
+                                .username}**'s MT join request`)
+                    } else {
+                        await roblox.handleJoinRequest(mtGroupId, userId, false)
+                        await (new DiscordMessageJob()).perform('log', `Declined **${request.requester
+                                .username}**'s MT join request`)
+                    }
                 }
-            }
+                cursor = requests.nextPageCursor
+            } while (cursor)
         } catch (err) {
             console.error(err.message)
         }


### PR DESCRIPTION
This PR implements the use of cursors when getting join requests. It now checks if the fetched join requests contains a cursor to a next page and will then get this page as well afterwards, until the cursors stop.

This PR resolves #18 