### PR TITLE
Hotfix/Trello webhook avatar pictures

### DIFF
--- a/app/services/trello.js
+++ b/app/services/trello.js
@@ -101,7 +101,7 @@ exports.getActionEmbed = async action => {
             description: `[\`${action.id}\`](${actionUrl}) ${action.data.card.name} - ${member.username}`,
             author: {
                 name: member.username,
-                icon_url: member.avatarUrl,
+                icon_url: `${member.avatarUrl}/170.png`,
                 url: `https://trello.com/${member.username}`
             },
             url: actionUrl,


### PR DESCRIPTION
This PR fixes the loading of the pictures in the embeds sent to the Trello webhook.