### PR TITLE
Extend training's default scope with 15 minutes

### DIFF
--- a/app/models/training.js
+++ b/app/models/training.js
@@ -67,7 +67,9 @@ module.exports = (sequelize, DataTypes) => {
 
     Training.loadScopes = models => {
         Training.addScope('defaultScope', {
-            where: { '$TrainingCancellation.id$': null, date: { [Op.gt]: sequelize.fn('NOW') }},
+            where: { '$TrainingCancellation.id$': null, date: {
+                [Op.gt]: sequelize.literal('NOW() + INTERVAL \'15 minutes\'')
+            }},
             include: [{
                 model: models.TrainingCancellation,
                 attributes: []


### PR DESCRIPTION
This PR extends the training's default active scope with 15 minutes.