### PR TITLE
Enhancement/Clean up routes

### DIFF
--- a/app/controllers/v1/catalog.js
+++ b/app/controllers/v1/catalog.js
@@ -9,9 +9,9 @@ exports.validate = method => {
             return [
                 header('authorization').exists().isString(),
                 query('CatalogContext').optional().isNumeric(),
-                query('Category').optional.isNumeric(),
-                query('CreatorID').optional.isNumeric(),
-                query('ResultsPerPage').optional.isNumeric(),
+                query('Category').optional().isNumeric(),
+                query('CreatorID').optional().isNumeric(),
+                query('ResultsPerPage').optional().isNumeric(),
                 query('Keyword').optional().isString(),
                 query('SortType').optional().isString(),
                 query('PageNumber').optional().isNumeric()

--- a/app/controllers/v1/catalog.js
+++ b/app/controllers/v1/catalog.js
@@ -1,5 +1,5 @@
 'use strict'
-const { header } = require('express-validator')
+const { header, query } = require('express-validator')
 
 const catalogService = require('../../services/catalog')
 
@@ -7,13 +7,20 @@ exports.validate = method => {
     switch (method) {
         case 'getItems':
             return [
-                header('authorization').exists().isString()
+                header('authorization').exists().isString(),
+                query('CatalogContext').optional().isNumeric(),
+                query('Category').optional.isNumeric(),
+                query('CreatorID').optional.isNumeric(),
+                query('ResultsPerPage').optional.isNumeric(),
+                query('Keyword').optional().isString(),
+                query('SortType').optional().isString(),
+                query('PageNumber').optional().isNumeric()
             ]
     }
 }
 
 exports.getItems = async (req, res) => {
-    const query_index = req.originalUrl.indexOf('?')
-    const query = query_index > 0 ? req.originalUrl.slice(query_index + 1) : ''
-    await res.json(await catalogService.getItems(query))
+    const queryStart = req.originalUrl.indexOf('?')
+    const queryString = queryStart > 0 ? req.originalUrl.slice(queryStart + 1) : ''
+    await res.json(await catalogService.getItems(queryString))
 }

--- a/app/controllers/v1/group.js
+++ b/app/controllers/v1/group.js
@@ -15,13 +15,6 @@ exports.validate = method => {
                 body('duration').exists().isNumeric(),
                 body('rankBack').exists().isBoolean()
             ]
-        case 'promote':
-            return [
-                header('authorization').exists().isString(),
-                param('groupId').isNumeric(),
-                param('userId').isNumeric(),
-                body('authorId').optional().isNumeric()
-            ]
         case 'getShout':
             return [
                 header('authorization').exists().isString(),
@@ -138,6 +131,14 @@ exports.validate = method => {
                 body('duration').exists().isNumeric(),
                 body('reason').exists().isString()
             ]
+        case 'putUser':
+            return [
+                header('authorization').exists().isString(),
+                param('groupId').isNumeric(),
+                param('userId').isNumeric(),
+                body('rank').exists().isNumeric(),
+                body('authorId').optional().isNumeric()
+            ]
     }
 }
 
@@ -148,10 +149,6 @@ exports.suspend = async (req, res) => {
         duration: req.body.duration,
         rankBack: req.body.rankBack
     })).get({ raw: true }))
-}
-
-exports.promote = async (req, res) => {
-    res.json(await groupService.promote(req.params.groupId, req.params.userId, req.body.authorId))
 }
 
 exports.getShout = async (req, res) => {
@@ -240,4 +237,11 @@ exports.extendSuspension = async (req, res) => {
         duration: req.body.duration,
         reason: req.body.reason
     })).get({ raw: true }))
+}
+
+exports.putUser = async (req, res) => {
+    res.json(await groupService.changeRank(req.params.groupId, req.params.userId, {
+        rank: req.body.rank,
+        authorId: req.body.authorId
+    }))
 }

--- a/app/controllers/v1/user.js
+++ b/app/controllers/v1/user.js
@@ -1,6 +1,5 @@
 'use strict'
 const { param, header, body } = require('express-validator')
-
 const userService = require('../../services/user')
 
 exports.validate = method => {
@@ -9,11 +8,6 @@ exports.validate = method => {
             return [
                 header('authorization').exists().isString(),
                 param('username').isString()
-            ]
-        case 'getJoinDate':
-            return [
-                header('authorization').exists().isString(),
-                param('userId').isNumeric()
             ]
         case 'hasBadge':
             return [
@@ -48,10 +42,6 @@ exports.validate = method => {
 
 exports.getUserId = async (req, res) => {
     res.json(await userService.getUserId(req.params.username))
-}
-
-exports.getJoinDate = async (req, res) => {
-    res.json(await userService.getJoinDate(req.params.userId))
 }
 
 exports.hasBadge = async (req, res) => {

--- a/app/routes/groups.js
+++ b/app/routes/groups.js
@@ -11,9 +11,6 @@ const { authenticate } = require('../middlewares/auth')
 router.post('/:groupId/suspensions', groupController.validate('suspend'), handleValidationResult, authenticate,
     parseParams, groupController.suspend)
 
-router.post('/:groupId/promote/:userId', groupController.validate('promote'), handleValidationResult,
-    authenticate, parseParams, groupController.promote)
-
 router.get('/:groupId/shout', groupController.validate('getShout'), handleValidationResult, authenticate,
     parseParams, groupController.getShout)
 
@@ -61,5 +58,8 @@ router.post('/:groupId/trainings/:trainingId/cancel', groupController.validate('
 
 router.post('/:groupId/suspensions/:userId/extend', groupController.validate('extendSuspension'),
     handleValidationResult, authenticate, parseParams, groupController.extendSuspension)
+
+router.put('/:groupId/users/:userId', groupController.validate('putUser'), handleValidationResult,
+    authenticate, parseParams, groupController.putUser)
 
 module.exports = router

--- a/app/routes/users.js
+++ b/app/routes/users.js
@@ -1,7 +1,6 @@
 'use strict'
 const express = require('express')
 const router = express.Router()
-
 const userController = require('../controllers/v1/user')
 
 const { handleValidationResult } = require('../middlewares/error')
@@ -10,9 +9,6 @@ const { authenticate } = require('../middlewares/auth')
 
 router.get('/:username/user-id', userController.validate('getUserId'), handleValidationResult, authenticate,
     userController.getUserId)
-
-router.get('/:userId/join-date', userController.validate('getJoinDate'), handleValidationResult, authenticate,
-    parseParams, userController.getJoinDate)
 
 router.get('/:userId/has-badge/:badgeId', userController.validate('hasBadge'), handleValidationResult,
     parseParams, authenticate, userController.hasBadge)

--- a/app/services/catalog.js
+++ b/app/services/catalog.js
@@ -1,9 +1,9 @@
 'use strict'
 const axios = require('axios')
 
-exports.getItems = async query => {
+exports.getItems = async queryString => {
     return (await axios({
         method: 'get',
-        url: `https://search.roblox.com/catalog/json?${query}`
+        url: `https://search.roblox.com/catalog/json?${queryString}`
     })).data
 }

--- a/app/services/group.js
+++ b/app/services/group.js
@@ -225,7 +225,7 @@ exports.changeRank = async (groupId, userId, options) => {
     if (rank === 99) throw createError(403, 'Can\'t change rank of partners')
     if (rank >= 200) throw createError(403, 'Can\'t change rank of HRs')
     if (!(options.rank === 1 || options.rank >= 3 && options.rank <= 5 || options.rank >= 100 && options.rank <= 102)) {
-        throw createError(403, 'Invalid rank')
+        throw createError(400, 'Invalid rank')
     }
     const newRole = await exports.setRank(groupId, userId, options.rank)
     const roles = await exports.getRoles(groupId)

--- a/app/services/group.js
+++ b/app/services/group.js
@@ -220,12 +220,16 @@ exports.extendSuspension = async (groupId, userId, options) => {
 
 exports.changeRank = async (groupId, userId, options) => {
     const rank = await userService.getRank(userId, groupId)
-    if (rank === 0) throw createError(403, 'Can only change rank of group members')
-    if (rank >= 100) throw createError(403, 'Can\'t change rank of MRs or higher')
-    const newRank = rank === 1 ? 3 : rank + 1
-    const newRole = await exports.setRank(groupId, userId, newRank)
+    if (rank === 0) throw createError(403, 'Can\'t change rank of non members')
+    if (rank === 2) throw createError(403, 'Can\'t change rank of suspended members')
+    if (rank === 99) throw createError(403, 'Can\'t change rank of partners')
+    if (rank >= 200) throw createError(403, 'Can\'t change rank of HRs')
+    if (!(options.rank === 1 || options.rank >= 3 && options.rank <= 5 || options.rank >= 100 && options.rank <= 102)) {
+        throw createError(403, 'Invalid rank')
+    }
+    const newRole = await exports.setRank(groupId, userId, options.rank)
     const roles = await exports.getRoles(groupId)
-    const oldRole = roles.roles.find(role => role.rank === options.rank)
+    const oldRole = roles.roles.find(role => role.rank === rank)
     const username = await userService.getUsername(userId)
     if (options.authorId) {
         const authorName = await userService.getUsername(options.authorId)

--- a/app/services/group.js
+++ b/app/services/group.js
@@ -33,26 +33,6 @@ exports.suspend = async (groupId, userId, options) => {
     return suspension
 }
 
-exports.promote = async (groupId, userId, authorId) => {
-    const rank = await userService.getRank(userId, groupId)
-    if (rank === 0) throw createError(403, 'Can only promote group members')
-    if (rank >= 100) throw createError(403, 'Can\'t promote MRs or higher')
-    const username = await userService.getUsername(userId)
-    const newRank = rank === 1 ? 3 : rank + 1
-    const newRole = await exports.setRank(groupId, userId, newRank)
-    const roles = await exports.getRoles(groupId)
-    const oldRole = roles.roles.find(role => role.rank === rank)
-    if (authorId) {
-        const authorName = await userService.getUsername(authorId)
-        await discordMessageJob('log', `**${authorName}** promoted **${username}** from **${oldRole
-            .name}** to **${newRole.name}**`)
-    } else {
-        await discordMessageJob('log', `Promoted **${username}** from **${oldRole.name}** to **${newRole
-            .name}**`)
-    }
-    return { oldRole, newRole }
-}
-
 exports.getShout = async groupId => {
     const client = robloxManager.getClient(groupId)
     const info = await client.apis.groups.getGroupInfo(groupId)
@@ -236,4 +216,24 @@ exports.extendSuspension = async (groupId, userId, options) => {
         reason: options.reason,
         suspensionId: suspension.id
     }, { individualHooks: true })
+}
+
+exports.changeRank = async (groupId, userId, options) => {
+    const rank = await userService.getRank(userId, groupId)
+    if (rank === 0) throw createError(403, 'Can only change rank of group members')
+    if (rank >= 100) throw createError(403, 'Can\'t change rank of MRs or higher')
+    const newRank = rank === 1 ? 3 : rank + 1
+    const newRole = await exports.setRank(groupId, userId, newRank)
+    const roles = await exports.getRoles(groupId)
+    const oldRole = roles.roles.find(role => role.rank === options.rank)
+    const username = await userService.getUsername(userId)
+    if (options.authorId) {
+        const authorName = await userService.getUsername(options.authorId)
+        await discordMessageJob('log', `**${authorName}** ${options.rank > rank ? 'promoted' : 
+            'demoted'} **${username}** from **${oldRole.name}** to **${newRole.name}**`)
+    } else {
+        await discordMessageJob('log', `${options.rank > rank ? 'Promoted' : 'demoted'} **${username}` +
+            `** from **${oldRole.name}** to **${newRole.name}**`)
+    }
+    return { oldRole, newRole }
 }

--- a/app/services/user.js
+++ b/app/services/user.js
@@ -8,12 +8,6 @@ exports.getUserId = username => {
     return client.getUserId(username)
 }
 
-exports.getJoinDate = async userId => {
-    const client = robloxManager.getClient()
-    const info = await client.apis.users.getUserInfo(userId)
-    return info.created
-}
-
 exports.hasBadge = async (userId, badgeId) => {
     const client = robloxManager.getClient(robloxConfig.defaultGroup)
     return (await client.apis.inventory.getUserOwnedItems({


### PR DESCRIPTION
This PR removes some of the endpoints that provide functionality that's already covered by other more general endpoints.
Validations were added for requests for the get items endpoint.
The group service's promote endpoint was removed in favor of the put user endpoint, this new endpoint is not restricted to promotions only but also allows demotes.

This PR resolves #54 