### PR TITLE
Fix/Also change rank in MT

### DIFF
--- a/app/jobs/payout-train-developers.js
+++ b/app/jobs/payout-train-developers.js
@@ -94,18 +94,18 @@ module.exports = async groupId => {
     // Only continue with payout logic if there are train transactions.
     if (trainTransactions.length > 0) {
         // Build a PayoutRequest from the developer sales information.
-        const recipients = []
-        for (const [id, developerSales] of Object.entries(developersSales)) {
-            recipients.push({
-                recipientId: parseInt(id),
-                recipientType: 'User',
-                amount: Math.ceil(developerSales.total.robux)
-            })
-        }
-        const payoutRequest = { PayoutType: 'FixedAmount', Recipients: recipients }
+        // const recipients = []
+        // for (const [id, developerSales] of Object.entries(developersSales)) {
+        //     recipients.push({
+        //         recipientId: parseInt(id),
+        //         recipientType: 'User',
+        //         amount: Math.ceil(developerSales.total.robux)
+        //     })
+        // }
+        // const payoutRequest = { PayoutType: 'FixedAmount', Recipients: recipients }
 
         // Make the payouts.
-        await client.apis.groups.payoutUser({ groupId, data: payoutRequest })
+        // await client.apis.groups.payoutUser({ groupId, data: payoutRequest })
 
         // Add new payout row.
         await Payout.create({ until: new Date(trainTransactions[0].created) })

--- a/app/jobs/payout-train-developers.js
+++ b/app/jobs/payout-train-developers.js
@@ -3,17 +3,26 @@ const robloxManager = require('../managers/roblox')
 const webSocketManager = require('../managers/web-socket')
 const { Payout } = require('../models')
 
+const developers = {
+    Supersnel11: { robloxId: 32851718, discordId: '228110777825886210' },
+    AmericanKay: { robloxId: 7050507, discordId: '175345544799977472' },
+    DerailingOn: { robloxId: 21753709, discordId: '273910287663497216' },
+    Happywalker: { robloxId: 6882179, discordId: '235476265325428736' },
+    BuildIntoTrains: { robloxId: 49248891, discordId: '263770097288609794' },
+    COEN1000: { robloxId: 5775031, discordId: '223172958510645250' }
+}
+
 const products = [
-    { id: 1371397, developerIds: [32851718] }, // Supersnel11
-    { id: 1547370, developerIds: [32851718] },
-    { id: 1373258, developerIds: [7050507] }, // AmericanKay
-    { id: 2300769, developerIds: [7050507] },
-    { id: 3886194, developerIds: [7050507] },
-    { id: 4787242, developerIds: [7050507] },
-    { id: 1399819, developerIds: [21753709, 6882179] }, // DerailingOn, Happywalker
-    { id: 1492453, developerIds: [49248891] }, // BuildIntoTrains
-    { id: 1426909, developerIds: [5775031] }, // COEN1000
-    { id: 2297243, developerIds: [5775031] }
+    { id: 1371397, developers: [developers.Supersnel11] },
+    { id: 1547370, developers: [developers.Supersnel11] },
+    { id: 1373258, developers: [developers.AmericanKay] },
+    { id: 2300769, developers: [developers.AmericanKay] },
+    { id: 3886194, developers: [developers.AmericanKay] },
+    { id: 4787242, developers: [developers.AmericanKay] },
+    { id: 1399819, developers: [developers.DerailingOn, developers.Happywalker] },
+    { id: 1492453, developers: [developers.BuildIntoTrains] },
+    { id: 1426909, developers: [developers.COEN1000] },
+    { id: 2297243, developers: [developers.COEN1000] }
 ]
 
 const PAY_RATE = 0.5
@@ -54,17 +63,26 @@ module.exports = async groupId => {
     // Get developer specific sales information from the train transactions.
     const developersSales = {}
     for (const product of products) {
-        for (const id of product.developerIds) {
-            if (!developersSales[id]) developersSales[id] = { total: { amount: 0, robux: 0 }, sales: {}}
-            developersSales[id].sales[product.id] = { amount: 0, robux: 0 }
+        for (const developer of product.developers) {
+            if (!developersSales[developer.robloxId]) {
+                developersSales[developer.robloxId] = {
+                    total: { amount: 0, robux: 0 },
+                    sales: {},
+                    discordId: developer.discordId
+                }
+            }
+            developersSales[developer.robloxId].sales[product.id] = {
+                amount: 0,
+                robux: 0,
+                name: (await client.apis.api.getProductInfo(product.id)).Name }
         }
     }
 
     for (const transaction of trainTransactions) {
         const product = products.find(product => product.id === transaction.details.id)
-        const gainings = transaction.currency.amount * 0.7 * PAY_RATE * (1 / product.developerIds.length)
-        for (const id of product.developerIds) {
-            const developerSales = developersSales[id]
+        const gainings = transaction.currency.amount * 0.7 * PAY_RATE * (1 / product.developers.length)
+        for (const developer of product.developers) {
+            const developerSales = developersSales[developer.robloxId]
             const productSales = developerSales.sales[product.id]
             productSales.amount++
             developerSales.total.amount++
@@ -76,18 +94,18 @@ module.exports = async groupId => {
     // Only continue with payout logic if there are train transactions.
     if (trainTransactions.length > 0) {
         // Build a PayoutRequest from the developer sales information.
-        // const recipients = []
-        // for (const [id, developerSales] of Object.entries(developersSales)) {
-        //     recipients.push({
-        //         recipientId: parseInt(id),
-        //         recipientType: 'User',
-        //         amount: Math.ceil(developerSales.total.robux)
-        //     })
-        // }
-        // const payoutRequest = { PayoutType: 'FixedAmount', Recipients: recipients }
+        const recipients = []
+        for (const [id, developerSales] of Object.entries(developersSales)) {
+            recipients.push({
+                recipientId: parseInt(id),
+                recipientType: 'User',
+                amount: Math.ceil(developerSales.total.robux)
+            })
+        }
+        const payoutRequest = { PayoutType: 'FixedAmount', Recipients: recipients }
 
         // Make the payouts.
-        // await client.apis.groups.payoutUser({ groupId, payoutRequest })
+        await client.apis.groups.payoutUser({ groupId, data: payoutRequest })
 
         // Add new payout row.
         await Payout.create({ until: new Date(trainTransactions[0].created) })

--- a/config/roblox.json
+++ b/config/roblox.json
@@ -1,4 +1,5 @@
 {
   "defaultGroup": 1018818,
-  "ownerId": 6882179
+  "ownerId": 6882179,
+  "mtGroup": 2661380
 }


### PR DESCRIPTION
Until now the bot would only automatically change ranks in the main group and once every night accept/decline pending requests in the MT group. Thus the ranks in the MT group were never updated, this PR fixes that.