### PR TITLE
Hotfix/Docker Compose volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - .:/opt/app
       - node_modules:/opt/app/node_modules
     command: /bin/bash ./bin/wait-for-it.sh db:5432 -- node ./bin/www
 
@@ -30,5 +29,4 @@ services:
       - postgres_data:/var/lib/postgresql/data
 
 volumes:
-  node_modules:
   postgres_data:


### PR DESCRIPTION
This PR removes the node_modules volume as an external volume and also removes the volume that could be used in combination with nodemon on the host system.