### PR TITLE
Fix/Bloxy XCSRF Token refreshing

### DIFF
--- a/app/managers/roblox.js
+++ b/app/managers/roblox.js
@@ -20,6 +20,9 @@ exports.init = async () => {
         const client = new Client({
             credentials: {
                 cookie: process.env.ROBLOX_COOKIE
+            },
+            rest: {
+                xcsrfRefreshInterval: 0
             }
         })
         // Set the client's requester to the custom requester.

--- a/package-lock.json
+++ b/package-lock.json
@@ -539,21 +539,21 @@
       "dev": true
     },
     "bloxy": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/bloxy/-/bloxy-5.0.2.tgz",
-      "integrity": "sha512-ABlCKUjlC0Jo1cYYeh07K4M8yqfKphCTbUNV+hDHtVtx8FikkWBz1r5ghjrcbefpYO/cVFaZ5Uf5uoht/rLASQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/bloxy/-/bloxy-5.0.3.tgz",
+      "integrity": "sha512-ZfLRRjmFxzU3iswNAvBwJ0kosKCcsdNrmeh59TDpKfcKdjyyzyrL6cHra3eTkGqT7bhr3U0HG2xtyjdvVy6hAA==",
       "requires": {
         "got": "^11.5.2",
         "lodash": "^4.17.19",
         "signalr-client": "0.0.19",
         "tough-cookie": "^4.0.0",
-        "tslib": "^2.0.0"
+        "tslib": "^2.0.3"
       },
       "dependencies": {
         "@sindresorhus/is": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.1.2.tgz",
-          "integrity": "sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ=="
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.0.tgz",
+          "integrity": "sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ=="
         },
         "@szmarczak/http-timer": {
           "version": "4.0.5",
@@ -599,11 +599,11 @@
           }
         },
         "got": {
-          "version": "11.7.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-11.7.0.tgz",
-          "integrity": "sha512-7en2XwH2MEqOsrK0xaKhbWibBoZqy+f1RSUoIeF1BLcnf+pyQdDsljWMfmOh+QKJwuvDIiKx38GtPh5wFdGGjg==",
+          "version": "11.8.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-11.8.0.tgz",
+          "integrity": "sha512-k9noyoIIY9EejuhaBNLyZ31D5328LeqnyPNXJQb2XlJZcKakLqN5m6O/ikhq/0lw56kUYS54fVm+D1x57YC9oQ==",
           "requires": {
-            "@sindresorhus/is": "^3.1.1",
+            "@sindresorhus/is": "^4.0.0",
             "@szmarczak/http-timer": "^4.0.5",
             "@types/cacheable-request": "^6.0.1",
             "@types/responselike": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@sentry/node": "^5.26.0",
     "axios": "^0.20.0",
-    "bloxy": "^5.0.2",
+    "bloxy": "^5.0.3",
     "debug": "^4.1.1",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",


### PR DESCRIPTION
[This PR](https://github.com/Visualizememe/bloxy/pull/115) on the Bloxy repo implemented the ability to set the RESTController's XCSRF Token refresh interval. 
Because of many appearing token validation errors, this PR sets the refresh interval to 0 so that a new token is fetched on every request.