### PR TITLE
Add more files to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,17 @@
+/.idea/*
+
 # Git
 .git
-.gitignore
 
 # Docker configuration
 Dockerfile
 docker-compose.yml
 
+ecosystem.config.js
+
 # NPM dependencies
 node_modules
 npm-debug.log
+
+.env
+*.key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     volumes:
       - /opt/app/node_modules
       - /storage/backups:/storage/backups
+      - ./private.key:/opt/app/private.key
+      - ./public.key:/opt/app/public.key
     labels:
       - traefik.enable=true
       - traefik.http.routers.nsadmin-api-production.rule=Host(`$HOST`)


### PR DESCRIPTION
This PR adds some more configuration to the .dockerignore:
- the user-specific .idea files are ignored
- .env is ignored
- the .key files are ignored