### PR TITLE
Add build badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 nsadmin-api
 ================
-[![Build status](https://badge.buildkite.com/63cd463b34afdd64116e2983ec91e8b2d1755b5d1b35373718.svg)](https://buildkite.com/ns-roblox/nsadmin-api)
+[![Discord](https://discordapp.com/api/guilds/761634353859395595/embed.png)](https://discord.gg/tJFNC5Y)
+[![Depfu](https://badges.depfu.com/badges/8d74b1db957c28ca20ea845f9181f3c4/count.svg)](https://depfu.com/github/guidojw/nsadmin-api?project_id=10273)
+[![Build status](https://badge.buildkite.com/63cd463b34afdd64116e2983ec91e8b2d1755b5d1b35373718.svg)](https://buildkite.com/guidos-projects/nsadmin-api)
 
 ## Prerequisites
 * [Node.js](https://nodejs.org/en/download/current/)


### PR DESCRIPTION
This PR adds build badges for the Discord support center and fixes the Buildkite badge (the organization slug changed).