### PR TITLE
Feature/Run database migrations on release

### DIFF
--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -11,4 +11,5 @@ fi
 cd /opt/docker/nsadmin-api/$STAGE || exit
 docker-compose pull app
 docker-compose build app
+docker-compose run --rm app npx sequelize-cli db:migrate
 docker-compose up -d app


### PR DESCRIPTION
This PR makes Buildkite run migrations on every release, so these don't have to be done manually anymore.