### PR TITLE
Hotfix/Parse bigints returned by Postgres as integers

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -1,6 +1,8 @@
 'use strict'
 require('dotenv').config()
 
+require('pg').defaults.parseInt8 = true // By default PG returns bigint columns as strings.
+
 module.exports = {
   development: {
     username: process.env.POSTGRES_USER,


### PR DESCRIPTION
Postgres returns bigints columns as string, so some functions in the code broke (oops didn't test #170 enough). This PR configures the pg module singleton so that bigints are parsed to integers first.