### PR TITLE
Feature/Dynamic Training Types

### DIFF
--- a/app/controllers/v1/group.js
+++ b/app/controllers/v1/group.js
@@ -70,6 +70,11 @@ class GroupController {
       .map(training => training.get({ plain: true })))
   }
 
+  async getTrainingTypes (req, res) {
+    res.json((await this._trainingService.getTrainingTypes(req.params.groupId))
+      .map(trainingType => trainingType.get({ plain: true })))
+  }
+
   async postSuspension (req, res) {
     res.json((await this._suspensionService.suspend(req.params.groupId, req.body.userId, req.body))
       .get({ raw: true }))
@@ -85,9 +90,18 @@ class GroupController {
       .get({ raw: true }))
   }
 
+  async postTrainingType (req, res) {
+    res.json((await this._trainingService.createTrainingType(req.params.groupId, req.body))
+      .get({ raw: true }))
+  }
+
   async putTraining (req, res) {
     res.json((await this._trainingService.changeTraining(req.params.groupId, req.params.trainingId, req.body))
       .get({ plain: true }))
+  }
+
+  async deleteTrainingType (req, res) {
+    res.json(await this._trainingService.deleteTrainingType(req.params.groupId, req.params.typeName))
   }
 
   validate (method) {

--- a/app/controllers/v1/group.js
+++ b/app/controllers/v1/group.js
@@ -21,6 +21,10 @@ class GroupController {
       .map(exile => exile.get({ raw: true })))
   }
 
+  async getRoles (req, res) {
+    res.json(await this._groupService.getRoles(req.params.groupId))
+  }
+
   async getGroup (req, res) {
     res.json(await this._groupService.getGroup(req.params.groupId))
   }
@@ -118,6 +122,11 @@ class GroupController {
           param('groupId').isInt().toInt()
         ]
       case 'getExiles':
+        return [
+          header('authorization').exists().isString(),
+          param('groupId').isInt().toInt()
+        ]
+      case 'getRoles':
         return [
           header('authorization').exists().isString(),
           param('groupId').isInt().toInt()

--- a/app/controllers/v1/group.js
+++ b/app/controllers/v1/group.js
@@ -100,8 +100,13 @@ class GroupController {
       .get({ plain: true }))
   }
 
+  async putTrainingType (req, res) {
+    res.json((await this._trainingService.changeTrainingType(req.params.groupId, req.params.typeId, req.body))
+      .get({ plain: true }))
+  }
+
   async deleteTrainingType (req, res) {
-    res.json(await this._trainingService.deleteTrainingType(req.params.groupId, req.params.typeName))
+    res.json(await this._trainingService.deleteTrainingType(req.params.groupId, req.params.typeId))
   }
 
   validate (method) {
@@ -251,6 +256,13 @@ class GroupController {
           body('changes.date').optional().isInt().toInt(),
           body('changes.notes').optional().isString(),
           body('changes.authorId').optional().isInt().toInt()
+        ]
+      case 'putTrainingType':
+        return [
+          header('authorization').exists().isString(),
+          param('groupId').isInt().toInt(),
+          param('typeId').isInt().toInt(),
+          body('changes.name').optional().isString(),
         ]
 
       case 'deleteTrainingType':

--- a/app/controllers/v1/group.js
+++ b/app/controllers/v1/group.js
@@ -235,7 +235,7 @@ class GroupController {
           header('authorization').exists().isString(),
           param('groupId').isInt().toInt(),
           body('authorId').exists().isInt().toInt(),
-          body('type').exists().isString(),
+          body('typeId').exists().isInt().toInt(),
           body('date').exists(),
           body('notes').optional().isString()
         ]

--- a/app/controllers/v1/group.js
+++ b/app/controllers/v1/group.js
@@ -252,7 +252,7 @@ class GroupController {
           param('groupId').isInt().toInt(),
           param('trainingId').isInt().toInt(),
           body('editorId').exists().isInt().toInt(),
-          body('changes.type').optional().isString(),
+          body('changes.typeId').optional().isInt().toInt(),
           body('changes.date').optional().isInt().toInt(),
           body('changes.notes').optional().isString(),
           body('changes.authorId').optional().isInt().toInt()
@@ -263,6 +263,7 @@ class GroupController {
           param('groupId').isInt().toInt(),
           param('typeId').isInt().toInt(),
           body('changes.name').optional().isString(),
+          body('changes.abbreviation').optional().isString()
         ]
 
       case 'deleteTrainingType':

--- a/app/controllers/v1/group.js
+++ b/app/controllers/v1/group.js
@@ -238,6 +238,7 @@ class GroupController {
           header('authorization').exists().isString(),
           param('groupId').isInt().toInt(),
           body('name').exists().isString(),
+          body('abbreviation').exists().isString()
         ]
 
       case 'putTraining':
@@ -256,7 +257,7 @@ class GroupController {
         return [
           header('authorization').exists().isString(),
           param('groupId').isInt().toInt(),
-          param('typeName').exists().isString()
+          param('typeId').isInt().toInt()
         ]
     }
   }

--- a/app/controllers/v1/group.js
+++ b/app/controllers/v1/group.js
@@ -196,6 +196,11 @@ class GroupController {
           param('trainingId').isInt().toInt(),
           query('scope').customSanitizer(decodeScopeQueryParam)
         ]
+      case 'getTrainingTypes':
+        return [
+          header('authorization').exists().isString(),
+          param('groupId').isInt().toInt()
+        ]
 
       case 'postTraining':
         return [
@@ -214,6 +219,12 @@ class GroupController {
           body('authorId').exists().isInt().toInt(),
           body('reason').exists().isString()
         ]
+      case 'postTrainingType':
+        return [
+          header('authorization').exists().isString(),
+          param('groupId').isInt().toInt(),
+          body('name').exists().isString(),
+        ]
 
       case 'putTraining':
         return [
@@ -225,6 +236,13 @@ class GroupController {
           body('changes.date').optional().isInt().toInt(),
           body('changes.notes').optional().isString(),
           body('changes.authorId').optional().isInt().toInt()
+        ]
+
+      case 'deleteTrainingType':
+        return [
+          header('authorization').exists().isString(),
+          param('groupId').isInt().toInt(),
+          param('typeName').exists().isString()
         ]
     }
   }

--- a/app/jobs/announce-trainings.js
+++ b/app/jobs/announce-trainings.js
@@ -98,10 +98,10 @@ function getTrainingsInfo (trainings, authors) {
 function groupTrainingsByType (trainings) {
   const result = {}
   for (const training of trainings) {
-    if (!result[training.type]) {
-      result[training.type] = []
+    if (!result[training.type.abbreviation]) {
+      result[training.type.abbreviation] = []
     }
-    result[training.type].push(training)
+    result[training.type.abbreviation].push(training)
   }
   return result
 }

--- a/app/jobs/announce-trainings.js
+++ b/app/jobs/announce-trainings.js
@@ -70,7 +70,7 @@ function getTrainingsInfo (trainings, authors) {
       const type = types[i]
       const typeTrainings = groupedTrainings[type]
 
-      result += `${type.toUpperCase()}:`
+      result += `${type}:`
 
       for (let j = 0; j < typeTrainings.length; j++) {
         const training = typeTrainings[j]

--- a/app/models/training-type.js
+++ b/app/models/training-type.js
@@ -3,7 +3,17 @@ module.exports = (sequelize, DataTypes) => {
   const TrainingType = sequelize.define('TrainingType', {
     name: {
       type: DataTypes.STRING,
-      primaryKey: true
+      primaryKey: false,
+      validate: {
+        notEmpty: true
+      }
+    },
+    abbreviation: {
+      type: DataTypes.STRING(8),
+      allowNull: false,
+      validate: {
+        notEmpty: true
+      }
     }
   }, {
     tableName: 'training_types'
@@ -13,7 +23,7 @@ module.exports = (sequelize, DataTypes) => {
     TrainingType.hasOne(models.Training, {
       foreignKey: {
         allowNull: false,
-        name: 'type'
+        name: 'typeId'
       }
     })
   }

--- a/app/models/training-type.js
+++ b/app/models/training-type.js
@@ -1,0 +1,22 @@
+'use strict'
+module.exports = (sequelize, DataTypes) => {
+  const TrainingType = sequelize.define('TrainingType', {
+    name: {
+      type: DataTypes.STRING,
+      primaryKey: true
+    }
+  }, {
+    tableName: 'training_types'
+  })
+
+  TrainingType.associate = models => {
+    TrainingType.hasOne(models.Training, {
+      foreignKey: {
+        allowNull: false,
+        name: 'type'
+      }
+    })
+  }
+
+  return TrainingType
+}

--- a/app/models/training-type.js
+++ b/app/models/training-type.js
@@ -24,7 +24,8 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: {
         allowNull: false,
         name: 'typeId'
-      }
+      },
+      as: 'type'
     })
   }
 

--- a/app/models/training.js
+++ b/app/models/training.js
@@ -11,11 +11,6 @@ module.exports = (sequelize, DataTypes) => {
     notes: {
       type: DataTypes.STRING
     },
-    type: {
-      type: DataTypes.ENUM,
-      allowNull: false,
-      values: ['cd', 'csr']
-    },
     date: {
       type: DataTypes.DATE,
       allowNull: false

--- a/app/models/training.js
+++ b/app/models/training.js
@@ -31,6 +31,13 @@ module.exports = (sequelize, DataTypes) => {
         name: 'trainingId'
       }
     })
+    Training.belongsTo(models.TrainingType, {
+      foreignKey: {
+        allowNull: false,
+        name: 'type'
+      },
+      onDelete: 'CASCADE'
+    })
   }
 
   Training.loadScopes = models => {

--- a/app/models/training.js
+++ b/app/models/training.js
@@ -31,6 +31,7 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
         name: 'typeId'
       },
+      as: 'type',
       onDelete: 'CASCADE'
     })
   }
@@ -46,6 +47,9 @@ module.exports = (sequelize, DataTypes) => {
       include: [{
         model: models.TrainingCancellation,
         attributes: []
+      }, {
+        model: models.TrainingType,
+        as: 'type'
       }]
     })
   }

--- a/app/models/training.js
+++ b/app/models/training.js
@@ -29,7 +29,7 @@ module.exports = (sequelize, DataTypes) => {
     Training.belongsTo(models.TrainingType, {
       foreignKey: {
         allowNull: false,
-        name: 'type'
+        name: 'typeId'
       },
       onDelete: 'CASCADE'
     })

--- a/app/routes/groups.js
+++ b/app/routes/groups.js
@@ -126,6 +126,29 @@ class GroupsRouter {
       groupController.cancelTraining.bind(groupController)
     )
 
+
+    router.route('/:groupId/trainings/types')
+      .get(
+        groupController.validate('getTrainingTypes'),
+        handleValidationResult,
+        authenticate,
+        groupController.getTrainingTypes.bind(groupController)
+      )
+      .post(
+        groupController.validate('postTrainingType'),
+        handleValidationResult,
+        authenticate,
+        groupController.postTrainingType.bind(groupController)
+      )
+
+    router.route('/:groupId/trainings/types/:typeName')
+      .delete(
+        groupController.validate('deleteTrainingType'),
+        handleValidationResult,
+        authenticate,
+        groupController.deleteTrainingType.bind(groupController)
+      )
+
     return router
   }
 }

--- a/app/routes/groups.js
+++ b/app/routes/groups.js
@@ -104,29 +104,6 @@ class GroupsRouter {
         groupController.postTraining.bind(groupController)
       )
 
-    router.route('/:groupId/trainings/:trainingId')
-      .get(
-        groupController.validate('getTraining'),
-        handleValidationResult,
-        authenticate,
-        groupController.getTraining.bind(groupController)
-      )
-      .put(
-        groupController.validate('putTraining'),
-        handleValidationResult,
-        authenticate,
-        groupController.putTraining.bind(groupController)
-      )
-
-    router.post(
-      '/:groupId/trainings/:trainingId/cancel',
-      groupController.validate('cancelTraining'),
-      handleValidationResult,
-      authenticate,
-      groupController.cancelTraining.bind(groupController)
-    )
-
-
     router.route('/:groupId/trainings/types')
       .get(
         groupController.validate('getTrainingTypes'),
@@ -148,6 +125,28 @@ class GroupsRouter {
         authenticate,
         groupController.deleteTrainingType.bind(groupController)
       )
+
+    router.route('/:groupId/trainings/:trainingId')
+      .get(
+        groupController.validate('getTraining'),
+        handleValidationResult,
+        authenticate,
+        groupController.getTraining.bind(groupController)
+      )
+      .put(
+        groupController.validate('putTraining'),
+        handleValidationResult,
+        authenticate,
+        groupController.putTraining.bind(groupController)
+      )
+
+    router.post(
+      '/:groupId/trainings/:trainingId/cancel',
+      groupController.validate('cancelTraining'),
+      handleValidationResult,
+      authenticate,
+      groupController.cancelTraining.bind(groupController)
+    )
 
     return router
   }

--- a/app/routes/groups.js
+++ b/app/routes/groups.js
@@ -30,6 +30,13 @@ class GroupsRouter {
       groupController.getExiles.bind(groupController)
     )
     router.get(
+      '/:groupId/roles',
+      groupController.validate('getRoles'),
+      handleValidationResult,
+      authenticate,
+      groupController.getRoles.bind(groupController)
+    )
+    router.get(
       '/:groupId',
       groupController.validate('getGroup'),
       handleValidationResult,

--- a/app/routes/groups.js
+++ b/app/routes/groups.js
@@ -118,13 +118,19 @@ class GroupsRouter {
         groupController.postTrainingType.bind(groupController)
       )
 
-    router.delete(
-      '/:groupId/trainings/types/:typeId',
-      groupController.validate('deleteTrainingType'),
-      handleValidationResult,
-      authenticate,
-      groupController.deleteTrainingType.bind(groupController)
-    )
+    router.route('/:groupId/trainings/types/:typeId')
+      .put(
+        groupController.validate('putTrainingType'),
+        handleValidationResult,
+        authenticate,
+        groupController.putTrainingType.bind(groupController)
+      )
+      .delete(
+        groupController.validate('deleteTrainingType'),
+        handleValidationResult,
+        authenticate,
+        groupController.deleteTrainingType.bind(groupController)
+      )
 
     router.route('/:groupId/trainings/:trainingId')
       .get(

--- a/app/routes/groups.js
+++ b/app/routes/groups.js
@@ -118,13 +118,13 @@ class GroupsRouter {
         groupController.postTrainingType.bind(groupController)
       )
 
-    router.route('/:groupId/trainings/types/:typeName')
-      .delete(
-        groupController.validate('deleteTrainingType'),
-        handleValidationResult,
-        authenticate,
-        groupController.deleteTrainingType.bind(groupController)
-      )
+    router.delete(
+      '/:groupId/trainings/types/:typeId',
+      groupController.validate('deleteTrainingType'),
+      handleValidationResult,
+      authenticate,
+      groupController.deleteTrainingType.bind(groupController)
+    )
 
     router.route('/:groupId/trainings/:trainingId')
       .get(

--- a/app/services/training.js
+++ b/app/services/training.js
@@ -115,8 +115,17 @@ class TrainingService {
     return TrainingType.findAll()
   }
 
-  async deleteTrainingType (_groupId, typeName) {
-    const trainingType = await TrainingType.findOne({ where: { name: typeName } })
+  async changeTrainingType (_groupId, typeId, { changes }) {
+    const trainingType = await TrainingType.findByPk(typeId)
+    if (!trainingType) {
+      throw new NotFoundError('Training type not found.')
+    }
+
+    return trainingType.update(changes)
+  }
+
+  async deleteTrainingType (_groupId, typeId) {
+    const trainingType = await TrainingType.findByPk(typeId)
     if (!trainingType) {
       throw new NotFoundError('Training type not found.')
     }

--- a/app/services/training.js
+++ b/app/services/training.js
@@ -1,6 +1,7 @@
 'use strict'
 const cron = require('node-schedule')
 
+const { Op } = require('sequelize')
 const { Training, TrainingCancellation, TrainingType } = require('../models')
 const { ConflictError, NotFoundError } = require('../errors')
 const { timeHelper } = require('../helpers')
@@ -14,9 +15,9 @@ class TrainingService {
     this._userService = userService
   }
 
-  async addTraining ({ type, authorId, date, notes }) {
+  async addTraining ({ typeId, authorId, date, notes }) {
     const training = await Training.create({
-      type: type.toLowerCase(),
+      typeId,
       authorId,
       date,
       notes
@@ -32,7 +33,7 @@ class TrainingService {
     const dateString = timeHelper.getDate(training.date)
     const timeString = timeHelper.getTime(training.date)
     const authorName = await this._userService.getUsername(training.authorId)
-    this._discordMessageJob.run(`**${authorName}** scheduled a **${training.type.toUpperCase()}** training at **${dateString} ${timeString} ${timeHelper.isDst(training.date) ? 'CEST' : 'CET'}**${training.notes ? ' with note "*' + training.notes + '*"' : ''}`)
+    this._discordMessageJob.run(`**${authorName}** scheduled a **${training.type.abbreviation}** training at **${dateString} ${timeString} ${timeHelper.isDst(training.date) ? 'CEST' : 'CET'}**${training.notes ? ' with note "*' + training.notes + '*"' : ''}`)
 
     return training
   }
@@ -75,8 +76,8 @@ class TrainingService {
     if (changes.notes) {
       this._discordMessageJob.run(`**${editorName}** changed training **${training.id}**'s notes to "*${training.notes}*"`)
     }
-    if (changes.type) {
-      this._discordMessageJob.run(`**${editorName}** changed training **${training.id}**'s type to **${training.type.toUpperCase()}**`)
+    if (changes.typeId) {
+      this._discordMessageJob.run(`**${editorName}** changed training **${training.id}**'s type to **${training.type.abbreviation}**`)
     }
     if (changes.date) {
       const dateString = timeHelper.getDate(training.date)
@@ -103,12 +104,12 @@ class TrainingService {
     return cancellation
   }
 
-  async createTrainingType (_groupId, { name }) {
-    if (await TrainingType.findOne({ where: { name } })) {
+  async createTrainingType (_groupId, { name, abbreviation }) {
+    if (await TrainingType.findOne({ where: { abbreviation: { [Op.iLike]: abbreviation.toLowerCase() } } })) {
       throw new ConflictError('Training type already exists.')
     }
 
-    return TrainingType.create({ name })
+    return TrainingType.create({ name, abbreviation })
   }
 
   getTrainingTypes () {

--- a/app/services/training.js
+++ b/app/services/training.js
@@ -1,8 +1,8 @@
 'use strict'
 const cron = require('node-schedule')
 
-const { Training, TrainingCancellation } = require('../models')
-const { NotFoundError } = require('../errors')
+const { Training, TrainingCancellation, TrainingType } = require('../models')
+const { ConflictError, NotFoundError } = require('../errors')
 const { timeHelper } = require('../helpers')
 
 const robloxConfig = require('../../config/roblox')
@@ -101,6 +101,27 @@ class TrainingService {
     this._discordMessageJob.run(`**${authorName}** cancelled training **${cancellation.trainingId}** with reason "*${cancellation.reason}*"`)
 
     return cancellation
+  }
+
+  async createTrainingType (_groupId, { name }) {
+    if (await TrainingType.findOne({ where: { name } })) {
+      throw new ConflictError('Training type already exists.')
+    }
+
+    return TrainingType.create({ name })
+  }
+
+  getTrainingTypes () {
+    return TrainingType.findAll()
+  }
+
+  async deleteTrainingType (_groupId, typeName) {
+    const trainingType = await TrainingType.findOne({ where: { name: typeName } })
+    if (!trainingType) {
+      throw new NotFoundError('Training type not found.')
+    }
+
+    return trainingType.destroy()
   }
 }
 

--- a/db/migrations/20201227023107-create-training-type.js
+++ b/db/migrations/20201227023107-create-training-type.js
@@ -25,16 +25,18 @@ module.exports = {
           abbreviation: trainingType.type
         }
       })
-    await queryInterface.bulkInsert('training_types', trainingTypes)
+    if (trainingTypes.length > 0) {
+      await queryInterface.bulkInsert('training_types', trainingTypes)
+    }
 
     const cdTrainingTypeId = await queryInterface.rawSelect(
       'training_types',
-      { where: { abbreviation: 'cd'}},
+      { where: { abbreviation: 'cd' } },
       ['id']
     )
     const csrTrainingTypeId = await queryInterface.rawSelect(
       'training_types',
-      { where: { abbreviation: 'csr'}},
+      { where: { abbreviation: 'csr' } },
       ['id']
     )
 
@@ -80,12 +82,12 @@ module.exports = {
 
     const cdTrainingTypeId = await queryInterface.rawSelect(
       'training_types',
-      { where: { abbreviation: 'cd'}},
+      { where: { abbreviation: 'cd' } },
       ['id']
     )
     const csrTrainingTypeId = await queryInterface.rawSelect(
       'training_types',
-      { where: { abbreviation: 'csr'}},
+      { where: { abbreviation: 'csr' } },
       ['id']
     )
 

--- a/db/migrations/20201227023107-create-training-type.js
+++ b/db/migrations/20201227023107-create-training-type.js
@@ -1,45 +1,107 @@
 'use strict'
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await  queryInterface.createTable('training_types', {
+    await queryInterface.createTable('training_types', {
+      id: {
+        type: Sequelize.INTEGER,
+        autoIncrement: true,
+        primaryKey: true
+      },
       name: {
-        primaryKey: true,
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      abbreviation: {
+        type: Sequelize.STRING(8),
+        allowNull: false
       }
     })
-    await queryInterface.bulkInsert('training_types', [{ name: 'cd' }, { name: 'csr' }])
+
+    const trainingTypes = (await queryInterface.sequelize.query('SELECT DISTINCT type FROM trainings'))
+      .shift()
+      .map(trainingType => {
+        return {
+          name: trainingType.type.toUpperCase(),
+          abbreviation: trainingType.type
+        }
+      })
+    await queryInterface.bulkInsert('training_types', trainingTypes)
+
+    const cdTrainingTypeId = await queryInterface.rawSelect(
+      'training_types',
+      { where: { abbreviation: 'cd'}},
+      ['id']
+    )
+    const csrTrainingTypeId = await queryInterface.rawSelect(
+      'training_types',
+      { where: { abbreviation: 'csr'}},
+      ['id']
+    )
 
     await queryInterface.changeColumn('trainings', 'type', {
-      type: `VARCHAR (255) USING CAST ( "type" as VARCHAR (255) )`,
+      type: `VARCHAR(255) USING CAST ( "type" as VARCHAR(255) )`,
+      allowNull: false
+    })
+    await queryInterface.dropEnum('enum_trainings_type')
+
+    if (cdTrainingTypeId) {
+      await queryInterface.bulkUpdate('trainings', { type: cdTrainingTypeId.toString() }, { type: 'cd' })
+    }
+    if (csrTrainingTypeId) {
+      await queryInterface.bulkUpdate('trainings', { type: csrTrainingTypeId.toString()}, { type: 'csr' })
+    }
+
+    await queryInterface.changeColumn('trainings', 'type', {
+      type: `INTEGER USING CAST ( "type" as INTEGER )`,
       allowNull: false
     })
     await queryInterface.addConstraint('trainings', {
       fields: ['type'],
       type: 'foreign key',
-      name: 'trainings_type_training_types_fk',
+      name: 'trainings_type_id_training_types_fk',
       references: {
         table: 'training_types',
-        field: 'name'
+        field: 'id'
       },
       onDelete: 'CASCADE'
     })
-    return queryInterface.dropEnum('enum_trainings_type')
+    return queryInterface.renameColumn('trainings', 'type', 'type_id')
   },
 
-  down: async (queryInterface /* , Sequelize */) => {
-    const trainingTypes = (await queryInterface.sequelize.query('SELECT DISTINCT type FROM trainings'))
-      .shift()
-      .map(training => training.type)
-    const newTrainingTypes = trainingTypes.filter(trainingType => trainingType !== 'cd' && trainingType !== 'csr')
-    await queryInterface.bulkDelete('trainings', { type: newTrainingTypes })
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('training_types', { abbreviation: { [Sequelize.Op.notIn]: ['cd', 'csr'] } })
 
-    await queryInterface.sequelize.query('CREATE TYPE enum_trainings_type AS ENUM (\'cd\', \'csr\')')
-    await queryInterface.removeConstraint('trainings', 'trainings_type_training_types_fk')
+    await queryInterface.renameColumn('trainings', 'type_id', 'type')
+    await queryInterface.removeConstraint('trainings', 'trainings_type_id_training_types_fk')
     await queryInterface.changeColumn('trainings', 'type', {
-      type: `enum_trainings_type USING CAST ( type AS enum_trainings_type )`,
+      type: `VARCHAR(255) USING CAST ( "type" as VARCHAR(255) )`,
       allowNull: false
     })
 
-    return queryInterface.dropTable('training_types')
+    const cdTrainingTypeId = await queryInterface.rawSelect(
+      'training_types',
+      { where: { abbreviation: 'cd'}},
+      ['id']
+    )
+    const csrTrainingTypeId = await queryInterface.rawSelect(
+      'training_types',
+      { where: { abbreviation: 'csr'}},
+      ['id']
+    )
+
+    await queryInterface.dropTable('training_types')
+
+    if (cdTrainingTypeId) {
+      await queryInterface.bulkUpdate('trainings', { type: 'cd' }, { type: cdTrainingTypeId.toString() })
+    }
+    if (csrTrainingTypeId) {
+      await queryInterface.bulkUpdate('trainings', { type: 'csr' }, { type: csrTrainingTypeId.toString() })
+    }
+
+    await queryInterface.sequelize.query('CREATE TYPE enum_trainings_type AS ENUM (\'cd\', \'csr\')')
+    return queryInterface.changeColumn('trainings', 'type', {
+      type: `enum_trainings_type USING CAST ( "type" AS enum_trainings_type )`,
+      allowNull: false
+    })
   }
 }

--- a/db/migrations/20201227023107-create-training-type.js
+++ b/db/migrations/20201227023107-create-training-type.js
@@ -20,9 +20,10 @@ module.exports = {
     const trainingTypes = (await queryInterface.sequelize.query('SELECT DISTINCT type FROM trainings'))
       .shift()
       .map(trainingType => {
+        const type = trainingType.type.toUpperCase()
         return {
-          name: trainingType.type.toUpperCase(),
-          abbreviation: trainingType.type
+          name: type,
+          abbreviation: type
         }
       })
     if (trainingTypes.length > 0) {
@@ -31,12 +32,12 @@ module.exports = {
 
     const cdTrainingTypeId = await queryInterface.rawSelect(
       'training_types',
-      { where: { abbreviation: 'cd' } },
+      { where: { abbreviation: 'CD' } },
       ['id']
     )
     const csrTrainingTypeId = await queryInterface.rawSelect(
       'training_types',
-      { where: { abbreviation: 'csr' } },
+      { where: { abbreviation: 'CSR' } },
       ['id']
     )
 
@@ -71,7 +72,7 @@ module.exports = {
   },
 
   down: async (queryInterface, Sequelize) => {
-    await queryInterface.bulkDelete('training_types', { abbreviation: { [Sequelize.Op.notIn]: ['cd', 'csr'] } })
+    await queryInterface.bulkDelete('training_types', { abbreviation: { [Sequelize.Op.notIn]: ['CD', 'CSR'] } })
 
     await queryInterface.renameColumn('trainings', 'type_id', 'type')
     await queryInterface.removeConstraint('trainings', 'trainings_type_id_training_types_fk')
@@ -82,12 +83,12 @@ module.exports = {
 
     const cdTrainingTypeId = await queryInterface.rawSelect(
       'training_types',
-      { where: { abbreviation: 'cd' } },
+      { where: { abbreviation: 'CD' } },
       ['id']
     )
     const csrTrainingTypeId = await queryInterface.rawSelect(
       'training_types',
-      { where: { abbreviation: 'csr' } },
+      { where: { abbreviation: 'CSR' } },
       ['id']
     )
 

--- a/db/migrations/20201227023107-create-training-type.js
+++ b/db/migrations/20201227023107-create-training-type.js
@@ -1,0 +1,45 @@
+'use strict'
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await  queryInterface.createTable('training_types', {
+      name: {
+        primaryKey: true,
+        type: Sequelize.STRING
+      }
+    })
+    await queryInterface.bulkInsert('training_types', [{ name: 'cd' }, { name: 'csr' }])
+
+    await queryInterface.changeColumn('trainings', 'type', {
+      type: `VARCHAR (255) USING CAST ( "type" as VARCHAR (255) )`,
+      allowNull: false
+    })
+    await queryInterface.addConstraint('trainings', {
+      fields: ['type'],
+      type: 'foreign key',
+      name: 'trainings_type_training_types_fk',
+      references: {
+        table: 'training_types',
+        field: 'name'
+      },
+      onDelete: 'CASCADE'
+    })
+    return queryInterface.dropEnum('enum_trainings_type')
+  },
+
+  down: async (queryInterface /* , Sequelize */) => {
+    const trainingTypes = (await queryInterface.sequelize.query('SELECT DISTINCT type FROM trainings'))
+      .shift()
+      .map(training => training.type)
+    const newTrainingTypes = trainingTypes.filter(trainingType => trainingType !== 'cd' && trainingType !== 'csr')
+    await queryInterface.bulkDelete('trainings', { type: newTrainingTypes })
+
+    await queryInterface.sequelize.query('CREATE TYPE enum_trainings_type AS ENUM (\'cd\', \'csr\')')
+    await queryInterface.removeConstraint('trainings', 'trainings_type_training_types_fk')
+    await queryInterface.changeColumn('trainings', 'type', {
+      type: `enum_trainings_type USING CAST ( type AS enum_trainings_type )`,
+      allowNull: false
+    })
+
+    return queryInterface.dropTable('training_types')
+  }
+}


### PR DESCRIPTION
This PR implements dynamic training types that can be added, changed and deleted.

The type abbreviations are now not lowercased anymore. Type abbreviations are unique and type names can be the same.

The migration is quite extensive:
What it does is look for the current training types (cd & csr) and add these to the new training types table if any training instance has them. Then it changes the type column to a type integer foreign key referencing the new table's id column. Lastly it renames the type column to type_id.

This PR resolves #173 