### PR TITLE
Hotfix/Remove old service out of DI config

### DIFF
--- a/config/application.yml
+++ b/config/application.yml
@@ -27,10 +27,6 @@ services:
     class: app/jobs
     main: AcceptJoinRequestsJob
     arguments: ['@RobloxManager', '@GroupService', '@DiscordMessageJob']
-  AcceptMtJoinRequestsJob:
-    class: app/jobs
-    main: AcceptMtJoinRequestsJob
-    arguments: ['@RobloxManager', '@UserService', '@GroupService', '@DiscordMessageJob']
   AnnounceTrainingsJob:
     class: app/jobs
     main: AnnounceTrainingsJob


### PR DESCRIPTION
#176 didn't remove the occurence of the job in the DI configuration, this PR fixes that.

Buildkite didn't find this, #123 should help with finding bugs like this.