### PR TITLE
Hotfix/Reload new training instances to include associations

### DIFF
--- a/app/services/training.js
+++ b/app/services/training.js
@@ -22,6 +22,7 @@ class TrainingService {
       date,
       notes
     })
+    await training.reload()
 
     this._announceTrainingsJob.run(robloxConfig.defaultGroup)
     cron.scheduleJob(


### PR DESCRIPTION
This PR reloads newly created training instances before trying to log the action and returning the trainings. This way the TrainingType instance that's included in Training's default scope gets added to the object and indexing training.type.abbreviation will work.