### PR TITLE
fix(Docker): change start commands to npm commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ COPY . .
 
 EXPOSE 3000
 
-CMD node ./bin/www
+CMD npm start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.nsadmin-api-production.rule=Host(`$HOST`)
       - traefik.http.routers.nsadmin-api-production.tls.certresolver=default
-    command: /bin/bash ./bin/wait-for-it.sh db:5432 -- node ./bin/www
+    command: /bin/bash ./bin/wait-for-it.sh db:5432 -- npm start
 
   db:
     image: postgres:11.2


### PR DESCRIPTION
The Dockerfile and dockercompose.yml did start ./bin/www directly instead of using the npm command. This PR fixes that.