### PR TITLE
hotfix(package.json): run start commands in sequence instead of parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "github:guidojw/nsadmin-api",
   "main": "app.js",
   "scripts": {
-    "start": "npm explore bloxy -- npm run build & node ./bin/www",
+    "start": "npm explore bloxy -- npm run build ; node ./bin/www",
     "start:dev": "nodemon ./bin/www",
     "lint": "eslint app"
   },


### PR DESCRIPTION
The start commands ran in parallel meaning it would try to start the project before building bloxy has finished. This PR fixes this.