### PR TITLE
fix(AnnounceTrainingsJob): pass this argument to run.bind

### DIFF
--- a/app/jobs/announce-trainings.js
+++ b/app/jobs/announce-trainings.js
@@ -19,7 +19,7 @@ class AnnounceTrainingsJob {
         cron.scheduleJob(
           jobName,
           new Date(training.date.getTime() + 30 * 60 * 1000),
-          this.run.bind(null, groupId)
+          this.run.bind(this, groupId)
         )
       }
     }


### PR DESCRIPTION
It passed null so using the index operator on this would give errors. Now the correct this keyword is provided.