### PR TITLE
feature(Traefik): makes use of new Traefik middlewares

### DIFF
--- a/app/loaders/express.js
+++ b/app/loaders/express.js
@@ -20,11 +20,11 @@ function init (app, container) {
   app.use(helmet())
   app.use(hpp())
 
-  app.use('/api/v1/groups', container.get('GroupsRouter'))
-  app.use('/api/v1/users', container.get('UsersRouter'))
-  app.use('/api/v1/bans', container.get('BansRouter'))
-  app.use('/api/v1/catalog', container.get('CatalogRouter'))
-  app.use('/api/v1/status', container.get('StatusRouter'))
+  app.use('/v1/groups', container.get('GroupsRouter'))
+  app.use('/v1/users', container.get('UsersRouter'))
+  app.use('/v1/bans', container.get('BansRouter'))
+  app.use('/v1/catalog', container.get('CatalogRouter'))
+  app.use('/v1/status', container.get('StatusRouter'))
 
   app.use(() => {
     throw new NotFoundError()

--- a/bin/www
+++ b/bin/www
@@ -13,7 +13,7 @@ const port = normalizePort(process.env.PORT || '3000')
 app.set('port', port)
 
 const server = http.createServer(app)
-const wss = new WebSocket.Server({ noServer: true, path: '/api/v1' })
+const wss = new WebSocket.Server({ noServer: true, path: '/v1' })
 
 wss.on('connection', webSocketManager.addConnection.bind(webSocketManager))
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,8 @@ services:
       - ./public.key:/opt/app/public.key
     labels:
       - traefik.enable=true
-      - traefik.http.routers.nsadmin-api-production.rule=Host(`$HOST`)
+      - traefik.http.routers.nsadmin-api-production.rule=Host(`$HOST`) && PathPrefix(`/api`)
+      - traefik.http.routers.nsadmin-api-production.middlewares=nsadmin-api-strip@file
       - traefik.http.routers.nsadmin-api-production.tls.certresolver=default
     command: /bin/bash ./bin/wait-for-it.sh db:5432 -- npm start
 


### PR DESCRIPTION
This PR configures Traefik to make use of the new middlewares implemented by https://github.com/guidojw/maya/pull/15. 
/api is stripped from all the routes as that's what one of the middlewares does.