### PR TITLE
fix(ErrorMiddleware): only include first error of every validation chain

### DIFF
--- a/app/middlewares/error.js
+++ b/app/middlewares/error.js
@@ -7,7 +7,7 @@ class ErrorMiddleware {
     if (errors.isEmpty()) {
       return next()
     }
-    this.sendErrors(res, 422, errors.array())
+    this.sendErrors(res, 422, errors.array({ firstErrorOnly: true }))
   }
 
   sendError (res, statusCode, message) {


### PR DESCRIPTION
For every validation chain, the middleware now only includes the first error.
