### PR TITLE
fix: change foreign key actions

### DIFF
--- a/.sequelizerc
+++ b/.sequelizerc
@@ -4,7 +4,7 @@ const path = require('path')
 
 module.exports = {
   config: path.resolve('config', 'database.js'),
-  'models-path': path.resolve('app', 'models'),
+  'models-path': path.resolve('src', 'models'),
   'seeders-path': path.resolve('db', 'seeders'),
   'migrations-path': path.resolve('db', 'migrations')
 }

--- a/db/migrations/20201226032621-change-user-ids-to-bigint.js
+++ b/db/migrations/20201226032621-change-user-ids-to-bigint.js
@@ -3,49 +3,50 @@
 module.exports = {
   up: (queryInterface /* , Sequelize */) => {
     return Promise.all([
-      _changeColumn(queryInterface, 'bans', 'author_id', 'BIGINT'),
-      _changeColumn(queryInterface, 'bans', 'user_id', 'BIGINT'),
+      changeColumnType(queryInterface, 'bans', 'author_id', 'BIGINT'),
+      changeColumnType(queryInterface, 'bans', 'user_id', 'BIGINT'),
 
-      _changeColumn(queryInterface, 'ban_cancellations', 'author_id', 'BIGINT'),
+      changeColumnType(queryInterface, 'ban_cancellations', 'author_id', 'BIGINT'),
 
-      _changeColumn(queryInterface, 'exiles', 'user_id', 'BIGINT'),
+      changeColumnType(queryInterface, 'exiles', 'user_id', 'BIGINT'),
 
-      _changeColumn(queryInterface, 'suspensions', 'author_id', 'BIGINT'),
-      _changeColumn(queryInterface, 'suspensions', 'user_id', 'BIGINT'),
+      changeColumnType(queryInterface, 'suspensions', 'author_id', 'BIGINT'),
+      changeColumnType(queryInterface, 'suspensions', 'user_id', 'BIGINT'),
 
-      _changeColumn(queryInterface, 'suspension_cancellations', 'author_id', 'BIGINT'),
+      changeColumnType(queryInterface, 'suspension_cancellations', 'author_id', 'BIGINT'),
 
-      _changeColumn(queryInterface, 'suspension_extensions', 'author_id', 'BIGINT'),
+      changeColumnType(queryInterface, 'suspension_extensions', 'author_id', 'BIGINT'),
 
-      _changeColumn(queryInterface, 'trainings', 'author_id', 'BIGINT'),
+      changeColumnType(queryInterface, 'trainings', 'author_id', 'BIGINT'),
 
-      _changeColumn(queryInterface, 'training_cancellations', 'author_id', 'BIGINT')
+      changeColumnType(queryInterface, 'training_cancellations', 'author_id', 'BIGINT')
     ])
   },
+
   down: (queryInterface /* , Sequelize */) => {
     return Promise.all([
-      _changeColumn(queryInterface, 'training_cancellations', 'author_id', 'INTEGER'),
+      changeColumnType(queryInterface, 'training_cancellations', 'author_id', 'INTEGER'),
 
-      _changeColumn(queryInterface, 'trainings', 'author_id', 'INTEGER'),
+      changeColumnType(queryInterface, 'trainings', 'author_id', 'INTEGER'),
 
-      _changeColumn(queryInterface, 'suspension_extensions', 'author_id', 'INTEGER'),
+      changeColumnType(queryInterface, 'suspension_extensions', 'author_id', 'INTEGER'),
 
-      _changeColumn(queryInterface, 'suspension_cancellations', 'author_id', 'INTEGER'),
+      changeColumnType(queryInterface, 'suspension_cancellations', 'author_id', 'INTEGER'),
 
-      _changeColumn(queryInterface, 'suspensions', 'user_id', 'INTEGER'),
-      _changeColumn(queryInterface, 'suspensions', 'author_id', 'INTEGER'),
+      changeColumnType(queryInterface, 'suspensions', 'user_id', 'INTEGER'),
+      changeColumnType(queryInterface, 'suspensions', 'author_id', 'INTEGER'),
 
-      _changeColumn(queryInterface, 'exiles', 'user_id', 'INTEGER'),
+      changeColumnType(queryInterface, 'exiles', 'user_id', 'INTEGER'),
 
-      _changeColumn(queryInterface, 'ban_cancellations', 'author_id', 'INTEGER'),
+      changeColumnType(queryInterface, 'ban_cancellations', 'author_id', 'INTEGER'),
 
-      _changeColumn(queryInterface, 'bans', 'user_id', 'INTEGER'),
-      _changeColumn(queryInterface, 'bans', 'author_id', 'INTEGER')
+      changeColumnType(queryInterface, 'bans', 'user_id', 'INTEGER'),
+      changeColumnType(queryInterface, 'bans', 'author_id', 'INTEGER')
     ])
   }
 }
 
-function _changeColumn(queryInterface, tableName, columnName, targetType) {
+function changeColumnType (queryInterface, tableName, columnName, targetType) {
   return queryInterface.changeColumn(tableName, columnName, {
     type: `${targetType} USING CAST("${columnName}" as ${targetType})`
   })

--- a/db/migrations/20201227023107-create-training-type.js
+++ b/db/migrations/20201227023107-create-training-type.js
@@ -43,7 +43,7 @@ module.exports = {
     )
 
     await queryInterface.changeColumn('trainings', 'type', {
-      type: `VARCHAR(255) USING CAST ( "type" as VARCHAR(255) )`,
+      type: 'VARCHAR(255) USING CAST ( "type" as VARCHAR(255) )',
       allowNull: false
     })
     await queryInterface.dropEnum('enum_trainings_type')
@@ -52,11 +52,11 @@ module.exports = {
       await queryInterface.bulkUpdate('trainings', { type: cdTrainingTypeId.toString() }, { type: 'cd' })
     }
     if (csrTrainingTypeId) {
-      await queryInterface.bulkUpdate('trainings', { type: csrTrainingTypeId.toString()}, { type: 'csr' })
+      await queryInterface.bulkUpdate('trainings', { type: csrTrainingTypeId.toString() }, { type: 'csr' })
     }
 
     await queryInterface.changeColumn('trainings', 'type', {
-      type: `INTEGER USING CAST ( "type" as INTEGER )`,
+      type: 'INTEGER USING CAST ( "type" as INTEGER )',
       allowNull: false
     })
     await queryInterface.addConstraint('trainings', {
@@ -78,7 +78,7 @@ module.exports = {
     await queryInterface.renameColumn('trainings', 'type_id', 'type')
     await queryInterface.removeConstraint('trainings', 'trainings_type_id_training_types_fk')
     await queryInterface.changeColumn('trainings', 'type', {
-      type: `VARCHAR(255) USING CAST ( "type" as VARCHAR(255) )`,
+      type: 'VARCHAR(255) USING CAST ( "type" as VARCHAR(255) )',
       allowNull: false
     })
 
@@ -104,7 +104,7 @@ module.exports = {
 
     await queryInterface.sequelize.query('CREATE TYPE enum_trainings_type AS ENUM (\'cd\', \'csr\')')
     return queryInterface.changeColumn('trainings', 'type', {
-      type: `enum_trainings_type USING CAST ( "type" AS enum_trainings_type )`,
+      type: 'enum_trainings_type USING CAST ( "type" AS enum_trainings_type )',
       allowNull: false
     })
   }

--- a/db/migrations/20210402235952-fix-constraints.js
+++ b/db/migrations/20210402235952-fix-constraints.js
@@ -47,10 +47,10 @@ module.exports = {
     )
 
     await Promise.all([
-      updateForeignKey(queryInterface, 'training_cancellations', 'training_id', 'trainings', 'CASCADE'),
-      updateForeignKey(queryInterface, 'suspension_extensions', 'suspension_id', 'suspensions', 'CASCADE'),
-      updateForeignKey(queryInterface, 'suspension_cancellations', 'suspension_id', 'suspensions', 'CASCADE'),
-      updateForeignKey(queryInterface, 'ban_cancellations', 'ban_id', 'bans', 'CASCADE')
+      updateForeignKey(queryInterface, 'training_cancellations', 'training_id', 'trainings'),
+      updateForeignKey(queryInterface, 'suspension_extensions', 'suspension_id', 'suspensions'),
+      updateForeignKey(queryInterface, 'suspension_cancellations', 'suspension_id', 'suspensions'),
+      updateForeignKey(queryInterface, 'ban_cancellations', 'ban_id', 'bans')
     ])
   }
 }

--- a/db/migrations/20210402235952-fix-constraints.js
+++ b/db/migrations/20210402235952-fix-constraints.js
@@ -1,0 +1,70 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await Promise.all([
+      updateForeignKey(queryInterface, 'ban_cancellations', 'ban_id', 'bans', 'CASCADE'),
+      updateForeignKey(queryInterface, 'suspension_cancellations', 'suspension_id', 'suspensions', 'CASCADE'),
+      updateForeignKey(queryInterface, 'suspension_extensions', 'suspension_id', 'suspensions', 'CASCADE'),
+      updateForeignKey(queryInterface, 'training_cancellations', 'training_id', 'trainings', 'CASCADE')
+    ])
+
+    await queryInterface.changeColumn(
+      'trainings',
+      'type_id',
+      { type: Sequelize.INTEGER, allowNull: true }
+    )
+    await queryInterface.removeConstraint('trainings', 'trainings_type_id_training_types_fk')
+    await queryInterface.addConstraint('trainings', {
+      fields: ['type_id'],
+      type: 'foreign key',
+      name: 'trainings_type_id_fkey',
+      references: {
+        table: 'training_types',
+        field: 'id'
+      },
+      onDelete: 'SET NULL'
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeConstraint('trainings', 'trainings_type_id_fkey')
+    await queryInterface.addConstraint('trainings', {
+      fields: ['type_id'],
+      type: 'foreign key',
+      name: 'trainings_type_id_training_types_fk',
+      references: {
+        table: 'training_types',
+        field: 'id'
+      },
+      onDelete: 'CASCADE'
+    })
+    await queryInterface.bulkDelete('trainings', { type_id: null }) // will delete trainings with typeId = null
+    await queryInterface.changeColumn(
+      'trainings',
+      'type_id',
+      { type: Sequelize.INTEGER, allowNull: false }
+    )
+
+    await Promise.all([
+      updateForeignKey(queryInterface, 'training_cancellations', 'training_id', 'trainings', 'CASCADE'),
+      updateForeignKey(queryInterface, 'suspension_extensions', 'suspension_id', 'suspensions', 'CASCADE'),
+      updateForeignKey(queryInterface, 'suspension_cancellations', 'suspension_id', 'suspensions', 'CASCADE'),
+      updateForeignKey(queryInterface, 'ban_cancellations', 'ban_id', 'bans', 'CASCADE')
+    ])
+  }
+}
+
+async function updateForeignKey (queryInterface, tableName, columnName, targetTableName, onDeleteAction = 'NO ACTION') {
+  await queryInterface.removeConstraint(tableName, `${tableName}_${columnName}_fkey`)
+  return queryInterface.addConstraint(tableName, {
+    fields: [columnName],
+    type: 'foreign key',
+    name: `${tableName}_${columnName}_fkey`,
+    references: {
+      table: targetTableName,
+      field: 'id'
+    },
+    onDelete: onDeleteAction
+  })
+}

--- a/src/models/ban-cancellation.js
+++ b/src/models/ban-cancellation.js
@@ -20,8 +20,11 @@ module.exports = (sequelize, DataTypes) => {
 
   BanCancellation.associate = models => {
     BanCancellation.belongsTo(models.Ban, {
-      foreignKey: { allowNull: false, name: 'banId' },
-      onDelete: 'cascade'
+      foreignKey: {
+        allowNull: false,
+        name: 'banId'
+      },
+      onDelete: 'CASCADE'
     })
   }
 

--- a/src/models/ban.js
+++ b/src/models/ban.js
@@ -33,7 +33,12 @@ module.exports = (sequelize, DataTypes) => {
   })
 
   Ban.associate = models => {
-    Ban.hasOne(models.BanCancellation, { foreignKey: { allowNull: false, name: 'banId' } })
+    Ban.hasOne(models.BanCancellation, {
+      foreignKey: {
+        allowNull: false,
+        name: 'banId'
+      }
+    })
   }
 
   Ban.loadScopes = models => {

--- a/src/models/suspension-cancellation.js
+++ b/src/models/suspension-cancellation.js
@@ -24,7 +24,7 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
         name: 'suspensionId'
       },
-      onDelete: 'cascade'
+      onDelete: 'CASCADE'
     })
   }
 

--- a/src/models/suspension-extension.js
+++ b/src/models/suspension-extension.js
@@ -28,7 +28,7 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
         name: 'suspensionId'
       },
-      onDelete: 'cascade'
+      onDelete: 'CASCADE'
     })
   }
 

--- a/src/models/training-cancellation.js
+++ b/src/models/training-cancellation.js
@@ -24,7 +24,7 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
         name: 'trainingId'
       },
-      onDelete: 'cascade'
+      onDelete: 'CASCADE'
     })
   }
 

--- a/src/models/training-type.js
+++ b/src/models/training-type.js
@@ -21,7 +21,7 @@ module.exports = (sequelize, DataTypes) => {
   })
 
   TrainingType.associate = models => {
-    TrainingType.hasOne(models.Training, {
+    TrainingType.hasMany(models.Training, {
       foreignKey: {
         allowNull: false,
         name: 'typeId'

--- a/src/models/training.js
+++ b/src/models/training.js
@@ -33,7 +33,7 @@ module.exports = (sequelize, DataTypes) => {
         name: 'typeId'
       },
       as: 'type',
-      onDelete: 'CASCADE'
+      onDelete: 'SET NULL'
     })
   }
 
@@ -41,9 +41,7 @@ module.exports = (sequelize, DataTypes) => {
     Training.addScope('defaultScope', {
       where: {
         '$TrainingCancellation.id$': null,
-        date: {
-          [Op.gt]: sequelize.literal('NOW() - INTERVAL \'15 minutes\'')
-        }
+        date: { [Op.gt]: sequelize.literal('NOW() - INTERVAL \'15 minutes\'') }
       },
       include: [{
         model: models.TrainingCancellation,


### PR DESCRIPTION
This PR migrates the onDelete action of most foreign keys to `CASCADE` (it was already declared like that in the model files but not put correctly in previous migrations). 
The onDelete action of the trainings_type_id_fkey was changed to `SET NULL` to allow training types to be deleted without deleting all trainings that have references to it.

This PR resolves #197 