### PR TITLE
fix: make typeId in Training model nullable

### DIFF
--- a/src/models/training.js
+++ b/src/models/training.js
@@ -28,10 +28,7 @@ module.exports = (sequelize, DataTypes) => {
       }
     })
     Training.belongsTo(models.TrainingType, {
-      foreignKey: {
-        allowNull: false,
-        name: 'typeId'
-      },
+      foreignKey: 'typeId',
       as: 'type',
       onDelete: 'SET NULL'
     })


### PR DESCRIPTION
Fixes regression caused by #219 where the column is nullable but not in the model declaration.