### PR TITLE
feat: migration for underscored sequelize_meta (part I)

### DIFF
--- a/db/migrations/20210403023244-create-sequelize-meta.js
+++ b/db/migrations/20210403023244-create-sequelize-meta.js
@@ -1,0 +1,23 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface /* , Sequelize */) => {
+    try {
+      const attributes = await queryInterface.describeTable('SequelizeMeta')
+      const rows = (await queryInterface.sequelize.query('SELECT name FROM "SequelizeMeta"'))
+        .shift()
+        .concat([{ name: '20210403023244-create-sequelize-meta.js' }])
+
+      await queryInterface.createTable('sequelize_meta', attributes)
+      await queryInterface.bulkInsert('sequelize_meta', rows)
+    } catch (err) {
+      if (!err.message.includes('No description found for "SequelizeMeta" table.')) {
+        throw err
+      }
+    }
+  },
+
+  down: async (/* queryInterface, Sequelize */) => {
+    // Do nothing, we want to keep the underscored table name.
+  }
+}


### PR DESCRIPTION
This is the first PR of two that migrates the SequelizeMeta table name to sequelize_meta, this PR clones the table and data to a new table with the underscored name. 
Make sure this is merged before part II.

This has to be done in two parts because Sequelize can't read from one migration data table and then write to another one. The second part removes the old table.

This migration has no down method implementation, as there's no way of knowing which of the two names one had first (it's automatically created by Sequelize) and everything else has always been underscored too anyways.