### PR TITLE
feat: migration for underscored sequelize_meta (part II)

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -16,7 +16,8 @@ module.exports = {
     define: {
       timestamps: false,
       underscored: true
-    }
+    },
+    migrationStorageTableName: 'sequelize_meta'
   },
 
   production: {
@@ -31,6 +32,7 @@ module.exports = {
       timestamps: false,
       underscored: true
     },
+    migrationStorageTableName: 'sequelize_meta',
     logging: false
   }
 }

--- a/db/migrations/20210403154022-delete-sequelize-meta.js
+++ b/db/migrations/20210403154022-delete-sequelize-meta.js
@@ -1,0 +1,18 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface /* , Sequelize */) => {
+    try {
+      await queryInterface.describeTable('SequelizeMeta')
+      await queryInterface.dropTable('SequelizeMeta')
+    } catch (err) {
+      if (!err.message.includes('No description found for "SequelizeMeta" table.')) {
+        throw err
+      }
+    }
+  },
+
+  down: async (/* queryInterface, Sequelize */) => {
+    // Do nothing, we want to keep using the underscored table name.
+  }
+}


### PR DESCRIPTION
! Make sure #221 is merged and its migrations are run before merging this !

This is part 2 of renaming the SequelizeMeta table to sequelize_meta. Last part cloned the table and its contents, this part deletes the old table and configures Sequelize to use the new one.