### PR TITLE
fix: ranking limits configurations

### DIFF
--- a/config/application.js
+++ b/config/application.js
@@ -1,8 +1,9 @@
 'use strict'
 
 module.exports = {
-  skippedRanks: [2, 3, 99],
+  skippedRanks: [2, 99],
   unbannableRanks: [99, [103]],
-  unchangeableRanks: [2, 99, [102]],
-  unexilableRanks: [99, [103]]
+  undemotableRanks: [2, 99, [103]],
+  unexilableRanks: [99, [103]],
+  unpromotableRanks: [[1, 2], 99, [102]]
 }


### PR DESCRIPTION
This PR fixes some issues with the ranking limits configurations. Main change is that the `unchangeableRanks` config has been divided into `undemotableRanks` and `unpromotableRanks`.