### PR TITLE
fix(axios-retry): increase delay

### DIFF
--- a/src/loaders/axios.ts
+++ b/src/loaders/axios.ts
@@ -3,5 +3,5 @@ import axiosRetry from 'axios-retry'
 
 axiosRetry(axios, {
   retryCondition: err => axiosRetry.isNetworkOrIdempotentRequestError(err) || err.response?.status === 429,
-  retryDelay: axiosRetry.exponentialDelay
+  retryDelay: retryCount => (retryCount === 1 ? 1 : ((retryCount - 1) ^ 2) + 1) * 60_000
 })


### PR DESCRIPTION
The PayoutTrainDevelopersJob still stops working and throws HTTP 429s. This is the case because axiosRetry.exponentialDelay returns only a few seconds for retryCount = 1, 2, 3...

The new retryDelay function follows a sequence with nth therm = `n^2 + 1` (2, 5, 10, 17...), with the result in minutes starting at 1.