### PR TITLE
fix(AcceptJoinRequestsJob): ignore errors

### DIFF
--- a/src/jobs/accept-join-requests.ts
+++ b/src/jobs/accept-join-requests.ts
@@ -28,13 +28,15 @@ export default class AcceptJoinRequestsJob implements BaseJob {
       for (const request of requests.data) {
         const userId = request.requester.userId
 
-        if (typeof await this.exileRepository.findOne({ where: { groupId, userId } }) !== 'undefined') {
-          await group.declineJoinRequest(userId)
-          await this.discordMessageJob.run(`Declined **${request.requester.username}**'s join request`)
-        } else {
-          await group.acceptJoinRequest(userId)
-          await this.discordMessageJob.run(`Accepted **${request.requester.username}**'s join request`)
-        }
+        try {
+          if (typeof await this.exileRepository.findOne({ where: { groupId, userId } }) !== 'undefined') {
+            await group.declineJoinRequest(userId)
+            await this.discordMessageJob.run(`Declined **${request.requester.username}**'s join request`)
+          } else {
+            await group.acceptJoinRequest(userId)
+            await this.discordMessageJob.run(`Accepted **${request.requester.username}**'s join request`)
+          }
+        } catch {} // Ignore error, this job is run frequently anyways.
       }
 
       cursor = requests.cursors.next


### PR DESCRIPTION
Most/all of the 403s on Sentry are originated from this job (and all somehow at X:20 and X:50 times), and since Node now throws on unhandled promise rejections, the Docker container would restart and thus stop ongoing tasks/jobs.

It doesn't really matter if accepting/declining a join request here fails since the job is ran frequently anyways, so this PR wraps it in a try/catch.