### PR TITLE
fix(Renovate): use bump range strategy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
-  "extends": ["config:base", ":preserveSemverRanges"],
+  "extends": ["config:base", ":preserveSemverRanges", ":disableDependencyDashboard"],
   "labels": ["dependencies"],
-  "dependencyDashboard": false,
+  "rangeStrategy": "bump",
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],


### PR DESCRIPTION
Dependency update PRs to a major version did not get updated if a patch was released quickly after the release of the major version. This PR fixes that by moving from the default rangeStrategy "replace" to "bump".