### PR TITLE
feat(Jobs): disable PayoutTrainDevelopersJob

### DIFF
--- a/src/configs/cron.ts
+++ b/src/configs/cron.ts
@@ -19,7 +19,7 @@ const cronConfig: { [key: string]: CronConfig } = {
     expression: '*/5 * * * *', // https://crontab.guru/#*/5_*_*_*_*
     job: TYPES.HealthCheckJob,
     args: ['main']
-  },
+  }
   // payoutTrainDevelopersJob: {
   //   expression: '0 12 * * 6', // https://crontab.guru/#0_12_*_*_6
   //   job: TYPES.PayoutTrainDevelopersJob,


### PR DESCRIPTION
As payouts are now done on a one-time basis, this PR disables the job. In the future the job will probably be deleted as its not necessary anymore.